### PR TITLE
Mobile auth and my reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,8 @@ app-example
 /ios
 /android
 node_modules
+
+# Local planning and issue automation artifacts
+docs/mvp-execution-plan.md
+scripts/export-gh-issues.mjs
+scripts/post-gh-issues.mjs

--- a/apps/mobile/app/(app)/(tabs)/reports.tsx
+++ b/apps/mobile/app/(app)/(tabs)/reports.tsx
@@ -1,32 +1,242 @@
-import { StyleSheet, Text, View } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { authorizedApiFetch } from '../../lib/api';
+import { useSession } from '../../providers/session-provider';
 
-export default function ReportsPlaceholderScreen() {
+type MyReport = {
+  id: string;
+  title: string;
+  category: string;
+  status: string;
+  anchorStatus: string;
+  integrityFlag: string;
+  createdAt: string | null;
+};
+
+type MyReportsResponse = {
+  data: MyReport[];
+  pagination: {
+    page: number;
+    pageSize: number;
+    total: number;
+    totalPages: number;
+  };
+};
+
+const formatCreatedAt = (value: string | null) => {
+  if (!value) {
+    return 'Unknown time';
+  }
+
+  return new Date(value).toLocaleString();
+};
+
+export default function ReportsScreen() {
+  const router = useRouter();
+  const { accessToken } = useSession();
+  const [reports, setReports] = useState<MyReport[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadReports = async () => {
+    if (!accessToken) {
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const payload = await authorizedApiFetch<MyReportsResponse>(
+        '/api/reports/mine?page=1&pageSize=20',
+        accessToken,
+      );
+      setReports(payload.data);
+    } catch (loadError) {
+      setReports([]);
+      setError(loadError instanceof Error ? loadError.message : 'Unable to load your reports.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void loadReports();
+  }, [accessToken]);
+
+  if (isLoading) {
+    return (
+      <View style={styles.centeredState}>
+        <ActivityIndicator size="large" color="#1f4d3f" />
+        <Text style={styles.helperCopy}>Loading your reports…</Text>
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.centeredState}>
+        <Text style={styles.errorTitle}>We couldn&apos;t load your reports.</Text>
+        <Text style={styles.helperCopy}>{error}</Text>
+        <Pressable onPress={loadReports} style={styles.secondaryButton}>
+          <Text style={styles.secondaryButtonText}>Retry</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  if (reports.length === 0) {
+    return (
+      <View style={styles.centeredState}>
+        <Text style={styles.emptyTitle}>No reports yet.</Text>
+        <Text style={styles.helperCopy}>
+          Reports you submit from Sidewalk will appear here once they are accepted.
+        </Text>
+      </View>
+    );
+  }
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Reports tab placeholder</Text>
-      <Text style={styles.copy}>
-        This tab is reserved for mobile report submission and history screens in the next
-        issue batches.
-      </Text>
-    </View>
+    <FlatList
+      contentContainerStyle={styles.listContent}
+      data={reports}
+      keyExtractor={(item) => item.id}
+      onRefresh={() => {
+        void loadReports();
+      }}
+      refreshing={isLoading}
+      renderItem={({ item }) => (
+        <Pressable
+          onPress={() => router.push(`/(app)/reports/${item.id}`)}
+          style={({ pressed }) => [styles.card, pressed ? styles.cardPressed : null]}
+        >
+          <Text style={styles.eyebrow}>{item.category}</Text>
+          <Text style={styles.cardTitle}>{item.title}</Text>
+          <Text style={styles.metaText}>
+            {item.status} · {item.anchorStatus}
+          </Text>
+          <Text style={styles.metaText}>{formatCreatedAt(item.createdAt)}</Text>
+          {item.integrityFlag !== 'NORMAL' ? (
+            <Text style={styles.warningText}>Integrity flag: {item.integrityFlag}</Text>
+          ) : null}
+        </Pressable>
+      )}
+      ListHeaderComponent={
+        <View style={styles.header}>
+          <Text style={styles.headerEyebrow}>My Reports</Text>
+          <Text style={styles.headerTitle}>Track what you have submitted.</Text>
+          <Text style={styles.headerCopy}>
+            Review report status, anchoring progress, and integrity alerts in one place.
+          </Text>
+        </View>
+      }
+      ItemSeparatorComponent={() => <View style={styles.separator} />}
+    />
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
+  centeredState: {
     flex: 1,
+    alignItems: 'center',
     justifyContent: 'center',
     padding: 24,
-    backgroundColor: '#fff',
+    backgroundColor: '#fffaf2',
   },
-  title: {
-    fontSize: 28,
-    fontWeight: '700',
-    color: '#112219',
-  },
-  copy: {
+  helperCopy: {
     marginTop: 12,
     color: '#51615a',
     lineHeight: 22,
+    textAlign: 'center',
+  },
+  errorTitle: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: '#112219',
+    textAlign: 'center',
+  },
+  emptyTitle: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: '#112219',
+    textAlign: 'center',
+  },
+  secondaryButton: {
+    marginTop: 18,
+    borderWidth: 1,
+    borderColor: '#cad5cf',
+    borderRadius: 999,
+    paddingHorizontal: 18,
+    paddingVertical: 12,
+    backgroundColor: '#ffffff',
+  },
+  secondaryButtonText: {
+    color: '#173d31',
+    fontWeight: '700',
+  },
+  listContent: {
+    padding: 20,
+    backgroundColor: '#fffaf2',
+  },
+  header: {
+    marginBottom: 18,
+  },
+  headerEyebrow: {
+    textTransform: 'uppercase',
+    letterSpacing: 2,
+    color: '#2f5d50',
+    fontWeight: '700',
+  },
+  headerTitle: {
+    marginTop: 8,
+    fontSize: 32,
+    fontWeight: '700',
+    color: '#112219',
+  },
+  headerCopy: {
+    marginTop: 10,
+    color: '#405149',
+    lineHeight: 22,
+  },
+  card: {
+    borderRadius: 24,
+    padding: 18,
+    backgroundColor: '#ffffff',
+  },
+  cardPressed: {
+    opacity: 0.8,
+  },
+  eyebrow: {
+    textTransform: 'uppercase',
+    letterSpacing: 1.5,
+    color: '#2f5d50',
+    fontWeight: '700',
+  },
+  cardTitle: {
+    marginTop: 8,
+    fontSize: 22,
+    fontWeight: '700',
+    color: '#112219',
+  },
+  metaText: {
+    marginTop: 6,
+    color: '#51615a',
+    lineHeight: 20,
+  },
+  warningText: {
+    marginTop: 10,
+    color: '#a13a29',
+    fontWeight: '600',
+  },
+  separator: {
+    height: 14,
   },
 });

--- a/apps/mobile/app/(app)/(tabs)/reports.tsx
+++ b/apps/mobile/app/(app)/(tabs)/reports.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'expo-router';
-import { useEffect, useState } from 'react';
+import { useEffect, useEffectEvent, useState } from 'react';
 import {
   ActivityIndicator,
   FlatList,
@@ -46,8 +46,11 @@ export default function ReportsScreen() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const loadReports = async () => {
+  const loadReports = useEffectEvent(async () => {
     if (!accessToken) {
+      setReports([]);
+      setError(null);
+      setIsLoading(false);
       return;
     }
 
@@ -66,7 +69,7 @@ export default function ReportsScreen() {
     } finally {
       setIsLoading(false);
     }
-  };
+  });
 
   useEffect(() => {
     void loadReports();

--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -1,6 +1,22 @@
-import { Stack } from 'expo-router';
+import { Redirect, Stack } from 'expo-router';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
+import { useSession } from '../providers/session-provider';
 
 export default function AppLayout() {
+  const { accessToken, isHydrating } = useSession();
+
+  if (isHydrating) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color="#1f4d3f" />
+      </View>
+    );
+  }
+
+  if (!accessToken) {
+    return <Redirect href="/(auth)/login" />;
+  }
+
   return (
     <Stack
       screenOptions={{
@@ -9,3 +25,12 @@ export default function AppLayout() {
     />
   );
 }
+
+const styles = StyleSheet.create({
+  loadingContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#fffaf2',
+  },
+});

--- a/apps/mobile/app/(auth)/_layout.tsx
+++ b/apps/mobile/app/(auth)/_layout.tsx
@@ -1,6 +1,22 @@
-import { Stack } from 'expo-router';
+import { Redirect, Stack } from 'expo-router';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
+import { useSession } from '../providers/session-provider';
 
 export default function AuthLayout() {
+  const { accessToken, isHydrating } = useSession();
+
+  if (isHydrating) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color="#1f4d3f" />
+      </View>
+    );
+  }
+
+  if (accessToken) {
+    return <Redirect href="/(app)/(tabs)" />;
+  }
+
   return (
     <Stack
       screenOptions={{
@@ -9,3 +25,12 @@ export default function AuthLayout() {
     />
   );
 }
+
+const styles = StyleSheet.create({
+  loadingContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#f4efe6',
+  },
+});

--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -1,33 +1,259 @@
-import { Link } from 'expo-router';
-import { StyleSheet, Text, View } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useState } from 'react';
+import {
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { apiFetch } from '../lib/api';
+import { useSession } from '../providers/session-provider';
+
+type RequestOtpResponse = {
+  success: boolean;
+  expiresInSeconds: number;
+};
+
+type VerifyOtpResponse = {
+  accessToken: string;
+  refreshToken: string;
+  refreshTokenExpiresAt: string;
+  expiresIn: string;
+};
 
 export default function LoginScreen() {
+  const router = useRouter();
+  const { deviceId, signIn } = useSession();
+  const [email, setEmail] = useState('');
+  const [code, setCode] = useState('');
+  const [district, setDistrict] = useState('');
+  const [role, setRole] = useState<'CITIZEN' | 'AGENCY_ADMIN'>('CITIZEN');
+  const [otpRequested, setOtpRequested] = useState(false);
+  const [expiresInSeconds, setExpiresInSeconds] = useState<number | null>(null);
+  const [requestError, setRequestError] = useState<string | null>(null);
+  const [verifyError, setVerifyError] = useState<string | null>(null);
+  const [isRequesting, setIsRequesting] = useState(false);
+  const [isVerifying, setIsVerifying] = useState(false);
+
+  const canSubmit = Boolean(deviceId);
+
+  const handleRequestOtp = async () => {
+    if (!email.trim()) {
+      setRequestError('Email is required.');
+      return;
+    }
+
+    setIsRequesting(true);
+    setRequestError(null);
+    setVerifyError(null);
+
+    try {
+      const payload = await apiFetch<RequestOtpResponse>('/api/auth/request-otp', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email: email.trim(),
+        }),
+      });
+
+      setOtpRequested(true);
+      setExpiresInSeconds(payload.expiresInSeconds);
+    } catch (error) {
+      setRequestError(error instanceof Error ? error.message : 'Unable to request OTP.');
+    } finally {
+      setIsRequesting(false);
+    }
+  };
+
+  const handleVerifyOtp = async () => {
+    if (!deviceId) {
+      setVerifyError('Device session is still initializing. Try again in a moment.');
+      return;
+    }
+
+    setIsVerifying(true);
+    setVerifyError(null);
+
+    try {
+      const payload = await apiFetch<VerifyOtpResponse>('/api/auth/verify-otp', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email: email.trim(),
+          code: code.trim(),
+          district: district.trim() || undefined,
+          role,
+          deviceId,
+          clientType: 'mobile',
+        }),
+      });
+
+      await signIn({
+        accessToken: payload.accessToken,
+        refreshToken: payload.refreshToken,
+        refreshTokenExpiresAt: payload.refreshTokenExpiresAt,
+        email: email.trim(),
+        role,
+      });
+
+      router.replace('/(app)/(tabs)');
+    } catch (error) {
+      setVerifyError(error instanceof Error ? error.message : 'Unable to verify OTP.');
+    } finally {
+      setIsVerifying(false);
+    }
+  };
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.eyebrow}>Sidewalk Mobile</Text>
-      <Text style={styles.title}>Auth shell ready.</Text>
-      <Text style={styles.copy}>
-        This route is the foundation for OTP login and session restore in the next issue batch.
-      </Text>
-      <Link href="/(app)/(tabs)" style={styles.primaryButton}>
-        Continue to app shell
-      </Link>
-    </View>
+    <KeyboardAvoidingView
+      behavior={Platform.select({ ios: 'padding', default: undefined })}
+      style={styles.keyboardView}
+    >
+      <ScrollView contentContainerStyle={styles.container}>
+        <Text style={styles.eyebrow}>Sidewalk Mobile</Text>
+        <Text style={styles.title}>Sign in with OTP.</Text>
+        <Text style={styles.copy}>
+          Request a one-time code, verify it on this device, and continue into the
+          protected reporting workspace.
+        </Text>
+
+        <View style={styles.card}>
+          <Text style={styles.label}>Email</Text>
+          <TextInput
+            autoCapitalize="none"
+            autoComplete="email"
+            keyboardType="email-address"
+            onChangeText={setEmail}
+            placeholder="citizen@example.com"
+            placeholderTextColor="#7b8c84"
+            style={styles.input}
+            value={email}
+          />
+
+          <Pressable
+            disabled={isRequesting || !canSubmit}
+            onPress={handleRequestOtp}
+            style={({ pressed }) => [
+              styles.primaryButton,
+              (pressed || isRequesting || !canSubmit) && styles.buttonPressed,
+            ]}
+          >
+            <Text style={styles.primaryButtonText}>
+              {isRequesting ? 'Sending…' : 'Request OTP'}
+            </Text>
+          </Pressable>
+
+          {expiresInSeconds ? (
+            <Text style={styles.successText}>
+              OTP issued. It expires in about {Math.ceil(expiresInSeconds / 60)} minutes.
+            </Text>
+          ) : null}
+          {requestError ? <Text style={styles.errorText}>{requestError}</Text> : null}
+          {!canSubmit ? (
+            <Text style={styles.helperText}>Preparing this device for sign-in…</Text>
+          ) : null}
+        </View>
+
+        <View style={styles.card}>
+          <Text style={styles.sectionTitle}>Verify Code</Text>
+          <Text style={styles.helperText}>
+            Enter the 6-digit OTP sent to your email to restore or create your session.
+          </Text>
+
+          <Text style={styles.label}>OTP Code</Text>
+          <TextInput
+            inputMode="numeric"
+            keyboardType="number-pad"
+            maxLength={6}
+            onChangeText={setCode}
+            placeholder="123456"
+            placeholderTextColor="#7b8c84"
+            style={styles.input}
+            value={code}
+          />
+
+          {__DEV__ ? (
+            <>
+              <Text style={styles.label}>Role</Text>
+              <View style={styles.roleRow}>
+                {(['CITIZEN', 'AGENCY_ADMIN'] as const).map((roleOption) => (
+                  <Pressable
+                    key={roleOption}
+                    onPress={() => setRole(roleOption)}
+                    style={[
+                      styles.roleChip,
+                      role === roleOption ? styles.roleChipSelected : null,
+                    ]}
+                  >
+                    <Text
+                      style={[
+                        styles.roleChipText,
+                        role === roleOption ? styles.roleChipTextSelected : null,
+                      ]}
+                    >
+                      {roleOption === 'CITIZEN' ? 'Citizen' : 'Agency admin'}
+                    </Text>
+                  </Pressable>
+                ))}
+              </View>
+            </>
+          ) : null}
+
+          <Text style={styles.label}>District (optional)</Text>
+          <TextInput
+            onChangeText={setDistrict}
+            placeholder="Ikeja"
+            placeholderTextColor="#7b8c84"
+            style={styles.input}
+            value={district}
+          />
+
+          <Pressable
+            disabled={isVerifying || !otpRequested || !canSubmit}
+            onPress={handleVerifyOtp}
+            style={({ pressed }) => [
+              styles.primaryButton,
+              (pressed || isVerifying || !otpRequested || !canSubmit) && styles.buttonPressed,
+            ]}
+          >
+            <Text style={styles.primaryButtonText}>
+              {isVerifying ? 'Verifying…' : 'Verify OTP'}
+            </Text>
+          </Pressable>
+
+          {!otpRequested ? (
+            <Text style={styles.helperText}>Request a code before verifying.</Text>
+          ) : null}
+          {verifyError ? <Text style={styles.errorText}>{verifyError}</Text> : null}
+        </View>
+      </ScrollView>
+    </KeyboardAvoidingView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
+  keyboardView: {
     flex: 1,
+    backgroundColor: '#f4efe6',
+  },
+  container: {
+    flexGrow: 1,
     justifyContent: 'center',
     padding: 24,
-    backgroundColor: '#f4efe6',
+    gap: 18,
   },
   eyebrow: {
     textTransform: 'uppercase',
     letterSpacing: 2,
     color: '#2f5d50',
-    marginBottom: 12,
     fontWeight: '700',
   },
   title: {
@@ -36,18 +262,83 @@ const styles = StyleSheet.create({
     color: '#112219',
   },
   copy: {
-    marginTop: 16,
     color: '#405149',
     lineHeight: 22,
   },
-  primaryButton: {
-    marginTop: 28,
-    backgroundColor: '#1f4d3f',
-    color: '#f8fff8',
-    paddingHorizontal: 18,
-    paddingVertical: 14,
-    borderRadius: 999,
-    overflow: 'hidden',
+  card: {
+    padding: 20,
+    borderRadius: 24,
+    backgroundColor: '#fffaf2',
+    gap: 10,
+  },
+  sectionTitle: {
+    fontSize: 22,
     fontWeight: '700',
+    color: '#112219',
+  },
+  label: {
+    marginTop: 4,
+    fontWeight: '600',
+    color: '#1e2c26',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#d7d0c2',
+    borderRadius: 16,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    fontSize: 16,
+    backgroundColor: '#ffffff',
+    color: '#112219',
+  },
+  primaryButton: {
+    marginTop: 6,
+    alignItems: 'center',
+    borderRadius: 999,
+    backgroundColor: '#1f4d3f',
+    paddingHorizontal: 18,
+    paddingVertical: 15,
+  },
+  primaryButtonText: {
+    color: '#f8fff8',
+    fontWeight: '700',
+  },
+  buttonPressed: {
+    opacity: 0.7,
+  },
+  helperText: {
+    color: '#51615a',
+    lineHeight: 20,
+  },
+  successText: {
+    color: '#1f6a46',
+    lineHeight: 20,
+  },
+  errorText: {
+    color: '#9f2d2d',
+    lineHeight: 20,
+  },
+  roleRow: {
+    flexDirection: 'row',
+    gap: 10,
+  },
+  roleChip: {
+    borderWidth: 1,
+    borderColor: '#cad5cf',
+    borderRadius: 999,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    backgroundColor: '#ffffff',
+  },
+  roleChipSelected: {
+    borderColor: '#1f4d3f',
+    backgroundColor: '#e6f4ee',
+  },
+  roleChipText: {
+    color: '#405149',
+    fontWeight: '600',
+  },
+  roleChipTextSelected: {
+    color: '#173d31',
   },
 });

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,44 +1,26 @@
-import { StatusBar } from 'expo-status-bar';
-import { useEffect, useState } from 'react';
-import { StyleSheet, Text, View, ActivityIndicator } from 'react-native';
-import { getMobileEnv } from '../src/config/env';
+import { Redirect } from 'expo-router';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
+import { useSession } from './providers/session-provider';
 
-export default function App() {
-  const [status, setStatus] = useState<string>('Checking...');
-  const [loading, setLoading] = useState(true);
-  const { apiUrl } = getMobileEnv();
-  const healthEndpoint = `${apiUrl}/api/health`;
+export default function IndexScreen() {
+  const { accessToken, isHydrating } = useSession();
 
-  useEffect(() => {
-    fetch(healthEndpoint)
-      .then((res) => res.json())
-      .then((data) => {
-        const integrations = data.integrations
-          ? Object.entries(data.integrations)
-              .map(([name, value]) => `${name}: ${String(value)}`)
-              .join('\n')
-          : 'No integration details';
-        setStatus(`API: ${data.status}\n${integrations}`);
-        setLoading(false);
-      })
-      .catch((err) => {
-        setStatus(`Error connecting to API\n${healthEndpoint}`);
-        console.error(err);
-        setLoading(false);
-      });
-  }, [healthEndpoint]);
+  if (isHydrating) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color="#1f4d3f" />
+      </View>
+    );
+  }
 
-  return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Sidewalk 🌍</Text>
-
-      {loading ? (
-        <ActivityIndicator size="large" />
-      ) : (
-        <Text style={styles.status}>{status}</Text>
-      )}
-
-      <StatusBar style="auto" />
-    </View>
-  );
+  return <Redirect href={accessToken ? '/(app)/(tabs)' : '/(auth)/login'} />;
 }
+
+const styles = StyleSheet.create({
+  loadingContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#fffaf2',
+  },
+});

--- a/apps/mobile/app/lib/api.ts
+++ b/apps/mobile/app/lib/api.ts
@@ -1,19 +1,63 @@
 import Constants from 'expo-constants';
 
-const configuredUrl =
-  Constants.expoConfig?.extra?.apiBaseUrl ??
-  process.env.EXPO_PUBLIC_API_BASE_URL ??
-  'http://localhost:5001';
+const fallbackApiBaseUrl = 'http://localhost:5000';
 
-export const apiBaseUrl = configuredUrl.replace(/\/+$/, '');
+const resolveApiBaseUrl = () => {
+  const configuredUrl =
+    Constants.expoConfig?.extra?.apiBaseUrl ??
+    process.env.EXPO_PUBLIC_API_URL ??
+    process.env.EXPO_PUBLIC_API_BASE_URL ??
+    fallbackApiBaseUrl;
+
+  return configuredUrl.replace(/\/+$/, '');
+};
+
+export const apiBaseUrl = resolveApiBaseUrl();
+
+type ApiErrorPayload = {
+  error?: {
+    message?: string;
+  };
+};
+
+const readJsonPayload = async <T>(response: Response): Promise<(T & ApiErrorPayload) | null> => {
+  const text = await response.text();
+  if (!text) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text) as T & ApiErrorPayload;
+  } catch {
+    return null;
+  }
+};
+
+const toErrorMessage = (payload: ApiErrorPayload | null, fallback: string) =>
+  payload?.error?.message ?? fallback;
 
 export const apiFetch = async <T>(path: string, init?: RequestInit): Promise<T> => {
   const response = await fetch(`${apiBaseUrl}${path}`, init);
-  const payload = (await response.json()) as T & { error?: { message?: string } };
+  const payload = await readJsonPayload<T>(response);
 
   if (!response.ok) {
-    throw new Error(payload.error?.message ?? 'Request failed');
+    throw new Error(toErrorMessage(payload, 'Request failed'));
   }
 
-  return payload;
+  return (payload ?? {}) as T;
+};
+
+export const authorizedApiFetch = async <T>(
+  path: string,
+  accessToken: string,
+  init?: RequestInit,
+): Promise<T> => {
+  return apiFetch<T>(path, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+      ...(init?.headers ?? {}),
+    },
+  });
 };

--- a/apps/mobile/app/lib/session-storage.ts
+++ b/apps/mobile/app/lib/session-storage.ts
@@ -1,0 +1,93 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const ACCESS_TOKEN_KEY = 'sidewalk:mobile:access-token';
+const ACCESS_TOKEN_EXPIRES_AT_KEY = 'sidewalk:mobile:access-token-expires-at';
+const REFRESH_TOKEN_KEY = 'sidewalk:mobile:refresh-token';
+const REFRESH_TOKEN_EXPIRES_AT_KEY = 'sidewalk:mobile:refresh-token-expires-at';
+const EMAIL_KEY = 'sidewalk:mobile:email';
+const ROLE_KEY = 'sidewalk:mobile:role';
+const DEVICE_ID_KEY = 'sidewalk:mobile:device-id';
+
+export type StoredSession = {
+  accessToken: string;
+  accessTokenExpiresAt: string;
+  refreshToken: string;
+  refreshTokenExpiresAt: string;
+  email: string;
+  role?: 'CITIZEN' | 'AGENCY_ADMIN';
+};
+
+const createFallbackDeviceId = () =>
+  `device-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+
+export const getDeviceId = async () => {
+  const existing = await AsyncStorage.getItem(DEVICE_ID_KEY);
+  if (existing) {
+    return existing;
+  }
+
+  const generated =
+    typeof globalThis.crypto?.randomUUID === 'function'
+      ? globalThis.crypto.randomUUID()
+      : createFallbackDeviceId();
+
+  await AsyncStorage.setItem(DEVICE_ID_KEY, generated);
+  return generated;
+};
+
+export const persistSession = async (session: StoredSession) => {
+  await AsyncStorage.multiSet([
+    [ACCESS_TOKEN_KEY, session.accessToken],
+    [ACCESS_TOKEN_EXPIRES_AT_KEY, session.accessTokenExpiresAt],
+    [REFRESH_TOKEN_KEY, session.refreshToken],
+    [REFRESH_TOKEN_EXPIRES_AT_KEY, session.refreshTokenExpiresAt],
+    [EMAIL_KEY, session.email],
+    [ROLE_KEY, session.role ?? 'CITIZEN'],
+  ]);
+};
+
+export const readStoredSession = async (): Promise<StoredSession | null> => {
+  const entries = await AsyncStorage.multiGet([
+    ACCESS_TOKEN_KEY,
+    ACCESS_TOKEN_EXPIRES_AT_KEY,
+    REFRESH_TOKEN_KEY,
+    REFRESH_TOKEN_EXPIRES_AT_KEY,
+    EMAIL_KEY,
+    ROLE_KEY,
+  ]);
+
+  const values = Object.fromEntries(entries);
+
+  if (
+    !values[ACCESS_TOKEN_KEY] ||
+    !values[ACCESS_TOKEN_EXPIRES_AT_KEY] ||
+    !values[REFRESH_TOKEN_KEY] ||
+    !values[REFRESH_TOKEN_EXPIRES_AT_KEY] ||
+    !values[EMAIL_KEY]
+  ) {
+    return null;
+  }
+
+  return {
+    accessToken: values[ACCESS_TOKEN_KEY],
+    accessTokenExpiresAt: values[ACCESS_TOKEN_EXPIRES_AT_KEY],
+    refreshToken: values[REFRESH_TOKEN_KEY],
+    refreshTokenExpiresAt: values[REFRESH_TOKEN_EXPIRES_AT_KEY],
+    email: values[EMAIL_KEY],
+    role:
+      values[ROLE_KEY] === 'AGENCY_ADMIN' || values[ROLE_KEY] === 'CITIZEN'
+        ? values[ROLE_KEY]
+        : undefined,
+  };
+};
+
+export const clearStoredSession = async () => {
+  await AsyncStorage.multiRemove([
+    ACCESS_TOKEN_KEY,
+    ACCESS_TOKEN_EXPIRES_AT_KEY,
+    REFRESH_TOKEN_KEY,
+    REFRESH_TOKEN_EXPIRES_AT_KEY,
+    EMAIL_KEY,
+    ROLE_KEY,
+  ]);
+};

--- a/apps/mobile/app/providers/session-provider.tsx
+++ b/apps/mobile/app/providers/session-provider.tsx
@@ -1,25 +1,179 @@
 'use client';
 
-import { createContext, ReactNode, useContext, useMemo, useState } from 'react';
+import { createContext, ReactNode, useContext, useEffect, useState } from 'react';
+import { apiFetch } from '../lib/api';
+import {
+  clearStoredSession,
+  getDeviceId,
+  persistSession,
+  readStoredSession,
+  type StoredSession,
+} from '../lib/session-storage';
 
-type SessionState = {
+type SessionRole = 'CITIZEN' | 'AGENCY_ADMIN';
+
+type SessionContextValue = {
   accessToken: string | null;
-  setAccessToken: (token: string | null) => void;
+  refreshToken: string | null;
+  email: string | null;
+  role: SessionRole | null;
+  deviceId: string | null;
+  isHydrating: boolean;
+  signIn: (session: {
+    accessToken: string;
+    refreshToken: string;
+    refreshTokenExpiresAt: string;
+    email: string;
+    role: SessionRole;
+  }) => Promise<void>;
+  signOut: () => Promise<void>;
+  restoreSession: () => Promise<void>;
 };
 
-const SessionContext = createContext<SessionState | null>(null);
+type RefreshSessionResponse = {
+  accessToken: string;
+  refreshToken: string;
+  refreshTokenExpiresAt: string;
+  expiresIn: string;
+};
+
+const SessionContext = createContext<SessionContextValue | null>(null);
+
+const accessTokenExpiresAt = () => new Date(Date.now() + 15 * 60 * 1000).toISOString();
+
+const toStoredSession = (
+  session: StoredSession | {
+    accessToken: string;
+    refreshToken: string;
+    refreshTokenExpiresAt: string;
+    email: string;
+    role: SessionRole;
+  },
+): StoredSession => ({
+  accessToken: session.accessToken,
+  accessTokenExpiresAt:
+    'accessTokenExpiresAt' in session ? session.accessTokenExpiresAt : accessTokenExpiresAt(),
+  refreshToken: session.refreshToken,
+  refreshTokenExpiresAt: session.refreshTokenExpiresAt,
+  email: session.email,
+  role: session.role,
+});
 
 export function SessionProvider({ children }: Readonly<{ children: ReactNode }>) {
   const [accessToken, setAccessToken] = useState<string | null>(null);
-  const value = useMemo(
-    () => ({
-      accessToken,
-      setAccessToken,
-    }),
-    [accessToken],
-  );
+  const [refreshToken, setRefreshToken] = useState<string | null>(null);
+  const [email, setEmail] = useState<string | null>(null);
+  const [role, setRole] = useState<SessionRole | null>(null);
+  const [deviceId, setDeviceId] = useState<string | null>(null);
+  const [isHydrating, setIsHydrating] = useState(true);
 
-  return <SessionContext.Provider value={value}>{children}</SessionContext.Provider>;
+  const hydrateState = async (session: StoredSession) => {
+    setAccessToken(session.accessToken);
+    setRefreshToken(session.refreshToken);
+    setEmail(session.email);
+    setRole(session.role ?? 'CITIZEN');
+  };
+
+  const signOut = async () => {
+    setAccessToken(null);
+    setRefreshToken(null);
+    setEmail(null);
+    setRole(null);
+    await clearStoredSession();
+  };
+
+  const signIn = async (session: {
+    accessToken: string;
+    refreshToken: string;
+    refreshTokenExpiresAt: string;
+    email: string;
+    role: SessionRole;
+  }) => {
+    const stored = toStoredSession(session);
+    await persistSession(stored);
+    await hydrateState(stored);
+  };
+
+  const restoreSession = async () => {
+    const resolvedDeviceId = await getDeviceId();
+    setDeviceId(resolvedDeviceId);
+
+    const stored = await readStoredSession();
+    if (!stored) {
+      await signOut();
+      return;
+    }
+
+    if (new Date(stored.refreshTokenExpiresAt).getTime() <= Date.now()) {
+      await signOut();
+      return;
+    }
+
+    try {
+      const payload = await apiFetch<RefreshSessionResponse>('/api/auth/refresh', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          deviceId: resolvedDeviceId,
+          refreshToken: stored.refreshToken,
+          clientType: 'mobile',
+        }),
+      });
+
+      const refreshed = toStoredSession({
+        accessToken: payload.accessToken,
+        refreshToken: payload.refreshToken,
+        refreshTokenExpiresAt: payload.refreshTokenExpiresAt,
+        email: stored.email,
+        role: stored.role ?? 'CITIZEN',
+      });
+
+      await persistSession(refreshed);
+      await hydrateState(refreshed);
+    } catch {
+      await signOut();
+    }
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const hydrate = async () => {
+      try {
+        await restoreSession();
+      } finally {
+        if (!cancelled) {
+          setIsHydrating(false);
+        }
+      }
+    };
+
+    void hydrate();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <SessionContext.Provider
+      value={{
+        accessToken,
+        refreshToken,
+        email,
+        role,
+        deviceId,
+        isHydrating,
+        signIn,
+        signOut,
+        restoreSession,
+      }}
+    >
+      {children}
+    </SessionContext.Provider>
+  );
 }
 
 export const useSession = () => {

--- a/apps/mobile/app/providers/session-provider.tsx
+++ b/apps/mobile/app/providers/session-provider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, ReactNode, useContext, useEffect, useState } from 'react';
+import { createContext, ReactNode, useContext, useEffect, useEffectEvent, useState } from 'react';
 import { apiFetch } from '../lib/api';
 import {
   clearStoredSession,
@@ -94,7 +94,7 @@ export function SessionProvider({ children }: Readonly<{ children: ReactNode }>)
     await hydrateState(stored);
   };
 
-  const restoreSession = async () => {
+  const restoreSession = useEffectEvent(async () => {
     const resolvedDeviceId = await getDeviceId();
     setDeviceId(resolvedDeviceId);
 
@@ -135,7 +135,7 @@ export function SessionProvider({ children }: Readonly<{ children: ReactNode }>)
     } catch {
       await signOut();
     }
-  };
+  });
 
   useEffect(() => {
     let cancelled = false;


### PR DESCRIPTION
This delivers by turning the Expo shell into a working authenticated mobile surface. It adds real OTP login, persisted mobile sessions with refresh restore, Expo Router auth guards, and a first citizen-facing My Reports list backed by the existing API.
The changes are intentionally narrow and backward-compatible: no backend contracts were changed, existing detail routing remains intact, and the new mobile session/API helpers are isolated under apps/mobile/app/lib and providers.
Risk is low and concentrated in mobile auth/session behavior. The main follow-up before merge is to run mobile lint/typecheck once dependencies are installed locally.

closes #121
closes #122
closes #123
closes #124