### PR TITLE
Upload feat

### DIFF
--- a/apps/mobile/app/(app)/(tabs)/reports.tsx
+++ b/apps/mobile/app/(app)/(tabs)/reports.tsx
@@ -9,6 +9,7 @@ import {
   View,
 } from 'react-native';
 import { authorizedApiFetch } from '../../lib/api';
+import { ReportPillRow } from '../../components/report-pills';
 import { useSession } from '../../providers/session-provider';
 
 type MyReport = {
@@ -126,13 +127,14 @@ export default function ReportsScreen() {
         >
           <Text style={styles.eyebrow}>{item.category}</Text>
           <Text style={styles.cardTitle}>{item.title}</Text>
-          <Text style={styles.metaText}>
-            {item.status} · {item.anchorStatus}
-          </Text>
+          <ReportPillRow
+            items={[
+              { value: item.status },
+              { value: item.anchorStatus },
+              { value: item.integrityFlag },
+            ]}
+          />
           <Text style={styles.metaText}>{formatCreatedAt(item.createdAt)}</Text>
-          {item.integrityFlag !== 'NORMAL' ? (
-            <Text style={styles.warningText}>Integrity flag: {item.integrityFlag}</Text>
-          ) : null}
         </Pressable>
       )}
       ListHeaderComponent={
@@ -251,11 +253,6 @@ const styles = StyleSheet.create({
     marginTop: 6,
     color: '#51615a',
     lineHeight: 20,
-  },
-  warningText: {
-    marginTop: 10,
-    color: '#a13a29',
-    fontWeight: '600',
   },
   separator: {
     height: 14,

--- a/apps/mobile/app/(app)/reports/[reportId].tsx
+++ b/apps/mobile/app/(app)/reports/[reportId].tsx
@@ -10,6 +10,7 @@ import {
   View,
 } from 'react-native';
 import { authorizedApiFetch } from '../../lib/api';
+import { ReportPillRow } from '../../components/report-pills';
 import { useSession } from '../../providers/session-provider';
 
 type ReportDetail = {
@@ -50,7 +51,11 @@ const formatCoordinates = (coordinates: [number, number]) => {
 };
 
 export default function ReportDetailScreen() {
-  const { reportId } = useLocalSearchParams<{ reportId: string }>();
+  const { reportId, justSubmitted, anchorStatus } = useLocalSearchParams<{
+    reportId: string;
+    justSubmitted?: string;
+    anchorStatus?: string;
+  }>();
   const { accessToken } = useSession();
   const [report, setReport] = useState<ReportDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -106,9 +111,23 @@ export default function ReportDetailScreen() {
     <ScrollView contentContainerStyle={styles.container}>
       <Text style={styles.eyebrow}>{report.category}</Text>
       <Text style={styles.title}>{report.title}</Text>
-      <Text style={styles.meta}>
-        {report.status} · {report.anchor_status} · {report.integrity_flag}
-      </Text>
+      {justSubmitted === '1' ? (
+        <View style={styles.noticeCard}>
+          <Text style={styles.noticeTitle}>Report accepted</Text>
+          <Text style={styles.noticeText}>
+            {anchorStatus === 'ANCHOR_QUEUED'
+              ? 'Your report was accepted and blockchain anchoring is now queued.'
+              : 'Your report was accepted successfully.'}
+          </Text>
+        </View>
+      ) : null}
+      <ReportPillRow
+        items={[
+          { value: report.status },
+          { value: report.anchor_status },
+          { value: report.integrity_flag },
+        ]}
+      />
       <Text style={styles.description}>{report.description}</Text>
 
       <View style={styles.card}>
@@ -216,13 +235,24 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     color: '#112219',
   },
-  meta: {
-    color: '#405149',
-    lineHeight: 22,
-  },
   description: {
     color: '#1e2c26',
     lineHeight: 24,
+  },
+  noticeCard: {
+    borderRadius: 20,
+    padding: 16,
+    backgroundColor: '#e7f4ee',
+  },
+  noticeTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#173d31',
+  },
+  noticeText: {
+    marginTop: 6,
+    color: '#1f4d3f',
+    lineHeight: 21,
   },
   card: {
     borderRadius: 24,

--- a/apps/mobile/app/(app)/reports/new.tsx
+++ b/apps/mobile/app/(app)/reports/new.tsx
@@ -2,7 +2,7 @@ import * as ImagePicker from 'expo-image-picker';
 import * as Location from 'expo-location';
 import { Image } from 'expo-image';
 import { useRouter } from 'expo-router';
-import { useState } from 'react';
+import { startTransition, useMemo, useState } from 'react';
 import {
   KeyboardAvoidingView,
   Platform,
@@ -13,7 +13,8 @@ import {
   TextInput,
   View,
 } from 'react-native';
-import { authorizedApiFetch } from '../../lib/api';
+import { authorizedApiFetch, authorizedFetch } from '../../lib/api';
+import { ReportPill, ReportPillRow } from '../../components/report-pills';
 import { useSession } from '../../providers/session-provider';
 
 const reportCategories = [
@@ -35,12 +36,50 @@ type CreateReportResponse = {
   anchor_status: string;
 };
 
+type CreateMediaDraftResponse = {
+  draftId: string;
+};
+
+type UploadMediaResponse = {
+  url: string;
+};
+
+type FieldErrors = Partial<Record<'title' | 'description' | 'latitude' | 'longitude', string>>;
+
 type SelectedImage = {
+  id: string;
   uri: string;
   name: string;
-  mimeType: string | null;
+  mimeType: string;
   size: number | null;
+  uploadState: 'ready' | 'uploading' | 'uploaded' | 'failed';
+  uploadedUrl: string | null;
+  error: string | null;
 };
+
+const allowedMimeTypes = new Set(['image/jpeg', 'image/png', 'image/webp']);
+
+const inferMimeType = (asset: ImagePicker.ImagePickerAsset) => {
+  if (asset.mimeType && allowedMimeTypes.has(asset.mimeType)) {
+    return asset.mimeType;
+  }
+
+  const normalizedUri = asset.uri.toLowerCase();
+  if (normalizedUri.endsWith('.jpg') || normalizedUri.endsWith('.jpeg')) {
+    return 'image/jpeg';
+  }
+  if (normalizedUri.endsWith('.png')) {
+    return 'image/png';
+  }
+  if (normalizedUri.endsWith('.webp')) {
+    return 'image/webp';
+  }
+
+  return null;
+};
+
+const buildImageId = (asset: ImagePicker.ImagePickerAsset, index: number) =>
+  `${asset.assetId ?? asset.uri}-${index}`;
 
 export default function NewReportScreen() {
   const router = useRouter();
@@ -55,7 +94,25 @@ export default function NewReportScreen() {
   const [isLocating, setIsLocating] = useState(false);
   const [isPickingImages, setIsPickingImages] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [mediaMessage, setMediaMessage] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+
+  const uploadingCount = useMemo(
+    () => selectedImages.filter((image) => image.uploadState === 'uploading').length,
+    [selectedImages],
+  );
+
+  const resetFieldError = (field: keyof FieldErrors) => {
+    setFieldErrors((current) => {
+      if (!current[field]) {
+        return current;
+      }
+
+      const next = { ...current };
+      delete next[field];
+      return next;
+    });
+  };
 
   const handleUseCurrentLocation = async () => {
     setIsLocating(true);
@@ -74,6 +131,8 @@ export default function NewReportScreen() {
 
       setLatitude(position.coords.latitude.toFixed(6));
       setLongitude(position.coords.longitude.toFixed(6));
+      resetFieldError('latitude');
+      resetFieldError('longitude');
     } catch (locationError) {
       setError(
         locationError instanceof Error
@@ -87,12 +146,12 @@ export default function NewReportScreen() {
 
   const handlePickImages = async () => {
     setIsPickingImages(true);
-    setMediaMessage(null);
+    setError(null);
 
     try {
       const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
       if (!permission.granted) {
-        setMediaMessage('Photo library permission is required to select report images.');
+        setError('Photo library permission is required to select report images.');
         return;
       }
 
@@ -107,25 +166,132 @@ export default function NewReportScreen() {
         return;
       }
 
-      setSelectedImages(
-        result.assets.map((asset, index) => ({
+      const unsupported = result.assets.filter((asset) => !inferMimeType(asset));
+      if (unsupported.length > 0) {
+        setError('Only JPEG, PNG, and WebP images are supported right now.');
+      }
+
+      const nextImages: SelectedImage[] = [];
+      result.assets.forEach((asset, index) => {
+        const mimeType = inferMimeType(asset);
+        if (!mimeType) {
+          return;
+        }
+
+        nextImages.push({
+          id: buildImageId(asset, index),
           uri: asset.uri,
           name: asset.fileName ?? `selected-image-${index + 1}.jpg`,
-          mimeType: asset.mimeType ?? null,
+          mimeType,
           size: asset.fileSize ?? null,
-        })),
-      );
+          uploadState: 'ready',
+          uploadedUrl: null,
+          error: null,
+        });
+      });
 
-      setMediaMessage(
-        `${result.assets.length} image${result.assets.length === 1 ? '' : 's'} selected. Upload wiring lands in the next mobile batch.`,
-      );
+      startTransition(() => {
+        setSelectedImages(nextImages);
+      });
     } catch (pickerError) {
-      setMediaMessage(
-        pickerError instanceof Error ? pickerError.message : 'Unable to pick images.',
-      );
+      setError(pickerError instanceof Error ? pickerError.message : 'Unable to pick images.');
     } finally {
       setIsPickingImages(false);
     }
+  };
+
+  const validateForm = () => {
+    const nextErrors: FieldErrors = {};
+
+    if (!title.trim()) {
+      nextErrors.title = 'Title is required.';
+    }
+
+    if (!description.trim()) {
+      nextErrors.description = 'Description is required.';
+    }
+
+    const parsedLatitude = Number(latitude);
+    if (!Number.isFinite(parsedLatitude) || parsedLatitude < -90 || parsedLatitude > 90) {
+      nextErrors.latitude = 'Latitude must be between -90 and 90.';
+    }
+
+    const parsedLongitude = Number(longitude);
+    if (!Number.isFinite(parsedLongitude) || parsedLongitude < -180 || parsedLongitude > 180) {
+      nextErrors.longitude = 'Longitude must be between -180 and 180.';
+    }
+
+    setFieldErrors(nextErrors);
+
+    return {
+      isValid: Object.keys(nextErrors).length === 0,
+      parsedLatitude,
+      parsedLongitude,
+    };
+  };
+
+  const markImageState = (
+    imageId: string,
+    updates: Partial<Pick<SelectedImage, 'uploadState' | 'uploadedUrl' | 'error'>>,
+  ) => {
+    setSelectedImages((currentImages) =>
+      currentImages.map((image) => (image.id === imageId ? { ...image, ...updates } : image)),
+    );
+  };
+
+  const uploadImages = async (draftId: string) => {
+    if (!accessToken || selectedImages.length === 0) {
+      return [];
+    }
+
+    const uploadedUrls: string[] = [];
+
+    for (const image of selectedImages) {
+      markImageState(image.id, { uploadState: 'uploading', error: null });
+
+      const formData = new FormData();
+      formData.append('file', {
+        uri: image.uri,
+        name: image.name,
+        type: image.mimeType,
+      } as never);
+
+      try {
+        const response = await authorizedFetch('/api/media/upload', accessToken, {
+          method: 'POST',
+          contentType: null,
+          headers: {
+            'x-media-draft-id': draftId,
+          },
+          body: formData,
+        });
+
+        const payload = (await response.json()) as UploadMediaResponse & {
+          error?: { message?: string };
+        };
+
+        if (!response.ok) {
+          throw new Error(payload.error?.message ?? 'Image upload failed.');
+        }
+
+        uploadedUrls.push(payload.url);
+        markImageState(image.id, {
+          uploadState: 'uploaded',
+          uploadedUrl: payload.url,
+          error: null,
+        });
+      } catch (uploadError) {
+        const message =
+          uploadError instanceof Error ? uploadError.message : 'Image upload failed.';
+        markImageState(image.id, {
+          uploadState: 'failed',
+          error: message,
+        });
+        throw new Error(`Unable to upload "${image.name}". ${message}`);
+      }
+    }
+
+    return uploadedUrls;
   };
 
   const handleSubmit = async () => {
@@ -134,30 +300,31 @@ export default function NewReportScreen() {
       return;
     }
 
-    if (!title.trim() || !description.trim()) {
-      setError('Title and description are required.');
+    if (isSubmitting) {
       return;
     }
 
-    const parsedLatitude = Number(latitude);
-    const parsedLongitude = Number(longitude);
-
-    if (
-      !Number.isFinite(parsedLatitude) ||
-      parsedLatitude < -90 ||
-      parsedLatitude > 90 ||
-      !Number.isFinite(parsedLongitude) ||
-      parsedLongitude < -180 ||
-      parsedLongitude > 180
-    ) {
-      setError('Enter valid latitude and longitude values before submitting.');
+    const validation = validateForm();
+    if (!validation.isValid) {
+      setError('Fix the highlighted fields before submitting your report.');
       return;
     }
 
     setIsSubmitting(true);
     setError(null);
+    setSuccessMessage(null);
 
     try {
+      const draftPayload =
+        selectedImages.length > 0
+          ? await authorizedApiFetch<CreateMediaDraftResponse>('/api/media/drafts', accessToken, {
+              method: 'POST',
+              body: JSON.stringify({}),
+            })
+          : null;
+
+      const uploadedUrls = draftPayload ? await uploadImages(draftPayload.draftId) : [];
+
       const payload = await authorizedApiFetch<CreateReportResponse>(
         '/api/reports',
         accessToken,
@@ -167,16 +334,33 @@ export default function NewReportScreen() {
             title: title.trim(),
             description: description.trim(),
             category,
-            media_urls: [],
+            draft_id: draftPayload?.draftId,
+            media_urls: uploadedUrls,
             location: {
               type: 'Point',
-              coordinates: [parsedLongitude, parsedLatitude],
+              coordinates: [validation.parsedLongitude, validation.parsedLatitude],
             },
           }),
         },
       );
 
-      router.replace(`/(app)/reports/${payload.report_id}`);
+      const pendingMessage =
+        payload.anchor_status === 'ANCHOR_QUEUED'
+          ? 'Report accepted. Anchoring is queued and will finish shortly.'
+          : 'Report accepted successfully.';
+
+      setSuccessMessage(pendingMessage);
+
+      setTimeout(() => {
+        router.replace({
+          pathname: '/(app)/reports/[reportId]',
+          params: {
+            reportId: payload.report_id,
+            justSubmitted: '1',
+            anchorStatus: payload.anchor_status,
+          },
+        });
+      }, 500);
     } catch (submitError) {
       setError(submitError instanceof Error ? submitError.message : 'Unable to submit report.');
     } finally {
@@ -193,31 +377,41 @@ export default function NewReportScreen() {
         <Text style={styles.eyebrow}>Create Report</Text>
         <Text style={styles.title}>Capture the issue clearly.</Text>
         <Text style={styles.copy}>
-          Submit a citizen report with structured details, current coordinates, and prepared
-          image attachments for the upcoming upload flow.
+          Submit a report with text, coordinates, and image evidence. Media uploads are attached
+          before the report is created so the final submission stays consistent.
         </Text>
 
         <View style={styles.card}>
           <Text style={styles.label}>Title</Text>
           <TextInput
-            onChangeText={setTitle}
+            onChangeText={(value) => {
+              setTitle(value);
+              resetFieldError('title');
+            }}
             placeholder="Flooded drainage near Oba Akran"
             placeholderTextColor="#7b8c84"
-            style={styles.input}
+            style={[styles.input, fieldErrors.title ? styles.inputError : null]}
             value={title}
           />
+          {fieldErrors.title ? <Text style={styles.fieldError}>{fieldErrors.title}</Text> : null}
 
           <Text style={styles.label}>Description</Text>
           <TextInput
             multiline
             numberOfLines={5}
-            onChangeText={setDescription}
+            onChangeText={(value) => {
+              setDescription(value);
+              resetFieldError('description');
+            }}
             placeholder="Describe what is happening, where it is, and how it affects people."
             placeholderTextColor="#7b8c84"
-            style={[styles.input, styles.textArea]}
+            style={[styles.input, styles.textArea, fieldErrors.description ? styles.inputError : null]}
             textAlignVertical="top"
             value={description}
           />
+          {fieldErrors.description ? (
+            <Text style={styles.fieldError}>{fieldErrors.description}</Text>
+          ) : null}
 
           <Text style={styles.label}>Category</Text>
           <View style={styles.categoryGrid}>
@@ -225,7 +419,10 @@ export default function NewReportScreen() {
               <Pressable
                 key={option}
                 onPress={() => setCategory(option)}
-                style={[styles.categoryChip, category === option ? styles.categoryChipSelected : null]}
+                style={[
+                  styles.categoryChip,
+                  category === option ? styles.categoryChipSelected : null,
+                ]}
               >
                 <Text
                   style={[
@@ -247,27 +444,46 @@ export default function NewReportScreen() {
               <Text style={styles.label}>Latitude</Text>
               <TextInput
                 keyboardType="numeric"
-                onChangeText={setLatitude}
+                onChangeText={(value) => {
+                  setLatitude(value);
+                  resetFieldError('latitude');
+                }}
                 placeholder="6.6018"
                 placeholderTextColor="#7b8c84"
-                style={styles.input}
+                style={[styles.input, fieldErrors.latitude ? styles.inputError : null]}
                 value={latitude}
               />
+              {fieldErrors.latitude ? (
+                <Text style={styles.fieldError}>{fieldErrors.latitude}</Text>
+              ) : null}
             </View>
             <View style={styles.coordinateField}>
               <Text style={styles.label}>Longitude</Text>
               <TextInput
                 keyboardType="numeric"
-                onChangeText={setLongitude}
+                onChangeText={(value) => {
+                  setLongitude(value);
+                  resetFieldError('longitude');
+                }}
                 placeholder="3.3515"
                 placeholderTextColor="#7b8c84"
-                style={styles.input}
+                style={[styles.input, fieldErrors.longitude ? styles.inputError : null]}
                 value={longitude}
               />
+              {fieldErrors.longitude ? (
+                <Text style={styles.fieldError}>{fieldErrors.longitude}</Text>
+              ) : null}
             </View>
           </View>
 
-          <Pressable onPress={handleUseCurrentLocation} style={styles.secondaryButton}>
+          <Pressable
+            disabled={isLocating || isSubmitting}
+            onPress={handleUseCurrentLocation}
+            style={({ pressed }) => [
+              styles.secondaryButton,
+              pressed || isLocating || isSubmitting ? styles.buttonPressed : null,
+            ]}
+          >
             <Text style={styles.secondaryButtonText}>
               {isLocating ? 'Reading current location…' : 'Use current location'}
             </Text>
@@ -277,30 +493,55 @@ export default function NewReportScreen() {
         <View style={styles.card}>
           <Text style={styles.sectionTitle}>Images</Text>
           <Text style={styles.helperText}>
-            Select image attachments now. Submission in this batch still sends text and location
-            only; upload wiring follows in the next mobile batch.
+            Supported formats: JPEG, PNG, and WebP. Images upload first, then the report is
+            submitted with the final media URLs.
           </Text>
 
-          <Pressable onPress={handlePickImages} style={styles.secondaryButton}>
+          <Pressable
+            disabled={isPickingImages || isSubmitting}
+            onPress={handlePickImages}
+            style={({ pressed }) => [
+              styles.secondaryButton,
+              pressed || isPickingImages || isSubmitting ? styles.buttonPressed : null,
+            ]}
+          >
             <Text style={styles.secondaryButtonText}>
               {isPickingImages ? 'Opening photo library…' : 'Select images'}
             </Text>
           </Pressable>
 
-          {mediaMessage ? <Text style={styles.helperText}>{mediaMessage}</Text> : null}
-
           {selectedImages.length > 0 ? (
             <View style={styles.imageList}>
               {selectedImages.map((image) => (
-                <View key={image.uri} style={styles.imageCard}>
+                <View key={image.id} style={styles.imageCard}>
                   <Image contentFit="cover" source={{ uri: image.uri }} style={styles.imagePreview} />
                   <Text numberOfLines={1} style={styles.imageName}>
                     {image.name}
                   </Text>
+                  <ReportPill
+                    label={
+                      image.uploadState === 'ready'
+                        ? 'Ready'
+                        : image.uploadState === 'uploading'
+                          ? 'Uploading'
+                          : image.uploadState === 'uploaded'
+                            ? 'Uploaded'
+                            : 'Failed'
+                    }
+                    value={
+                      image.uploadState === 'uploaded'
+                        ? 'ANCHOR_SUCCESS'
+                        : image.uploadState === 'failed'
+                          ? 'ANCHOR_FAILED'
+                          : 'ANCHOR_QUEUED'
+                    }
+                  />
+                  {image.error ? <Text style={styles.fieldError}>{image.error}</Text> : null}
                   <Pressable
+                    disabled={isSubmitting || image.uploadState === 'uploading'}
                     onPress={() =>
                       setSelectedImages((currentImages) =>
-                        currentImages.filter((currentImage) => currentImage.uri !== image.uri),
+                        currentImages.filter((currentImage) => currentImage.id !== image.id),
                       )
                     }
                     style={styles.removeImageButton}
@@ -313,18 +554,38 @@ export default function NewReportScreen() {
           ) : null}
         </View>
 
+        <View style={styles.card}>
+          <Text style={styles.sectionTitle}>Submission State</Text>
+          <ReportPillRow
+            items={[
+              { value: 'PENDING', label: isSubmitting ? 'Submitting' : 'Ready to submit' },
+              {
+                value: uploadingCount > 0 ? 'ANCHOR_QUEUED' : 'ANCHOR_SUCCESS',
+                label:
+                  uploadingCount > 0
+                    ? `${uploadingCount} image${uploadingCount === 1 ? '' : 's'} uploading`
+                    : 'Uploads prepared',
+              },
+            ]}
+          />
+          <Text style={styles.helperText}>
+            Report submission is locked while uploads or the final create request are in flight.
+          </Text>
+        </View>
+
         {error ? <Text style={styles.errorText}>{error}</Text> : null}
+        {successMessage ? <Text style={styles.successText}>{successMessage}</Text> : null}
 
         <Pressable
-          disabled={isSubmitting}
+          disabled={isSubmitting || isLocating || isPickingImages}
           onPress={handleSubmit}
           style={({ pressed }) => [
             styles.primaryButton,
-            pressed || isSubmitting ? styles.buttonPressed : null,
+            pressed || isSubmitting || isLocating || isPickingImages ? styles.buttonPressed : null,
           ]}
         >
           <Text style={styles.primaryButtonText}>
-            {isSubmitting ? 'Submitting…' : 'Submit report'}
+            {isSubmitting ? 'Submitting report…' : 'Submit report'}
           </Text>
         </Pressable>
       </ScrollView>
@@ -380,6 +641,13 @@ const styles = StyleSheet.create({
     paddingVertical: 14,
     backgroundColor: '#ffffff',
     color: '#112219',
+  },
+  inputError: {
+    borderColor: '#c76a5c',
+  },
+  fieldError: {
+    color: '#9f2d2d',
+    lineHeight: 20,
   },
   textArea: {
     minHeight: 120,
@@ -449,6 +717,10 @@ const styles = StyleSheet.create({
     color: '#9f2d2d',
     lineHeight: 21,
   },
+  successText: {
+    color: '#1f6a46',
+    lineHeight: 21,
+  },
   buttonPressed: {
     opacity: 0.7,
   },
@@ -458,12 +730,12 @@ const styles = StyleSheet.create({
     gap: 10,
   },
   imageCard: {
-    width: 96,
+    width: 108,
     gap: 6,
   },
   imagePreview: {
-    width: 96,
-    height: 96,
+    width: 108,
+    height: 108,
     borderRadius: 16,
     backgroundColor: '#f1ece3',
   },

--- a/apps/mobile/app/components/report-pills.tsx
+++ b/apps/mobile/app/components/report-pills.tsx
@@ -1,0 +1,86 @@
+import { StyleSheet, Text, View } from 'react-native';
+
+type PillTone = 'neutral' | 'success' | 'warning' | 'danger';
+
+const toneByStatus: Record<string, PillTone> = {
+  PENDING: 'warning',
+  ACKNOWLEDGED: 'neutral',
+  RESOLVED: 'success',
+  REJECTED: 'danger',
+  ESCALATED: 'warning',
+  ANCHOR_QUEUED: 'warning',
+  ANCHOR_SUCCESS: 'success',
+  ANCHOR_FAILED: 'danger',
+  NORMAL: 'success',
+  SUSPICIOUS: 'danger',
+};
+
+const labelize = (value: string) => value.replaceAll('_', ' ').toLowerCase().replace(/\b\w/g, (c) => c.toUpperCase());
+
+const stylesForTone = StyleSheet.create({
+  base: {
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 7,
+    borderWidth: 1,
+  },
+  neutral: {
+    backgroundColor: '#edf1f3',
+    borderColor: '#cbd5db',
+  },
+  success: {
+    backgroundColor: '#e7f4ee',
+    borderColor: '#8ab79d',
+  },
+  warning: {
+    backgroundColor: '#fbefcf',
+    borderColor: '#d4b15c',
+  },
+  danger: {
+    backgroundColor: '#f9e3df',
+    borderColor: '#cf8a7b',
+  },
+  text: {
+    color: '#173d31',
+    fontSize: 12,
+    fontWeight: '700',
+  },
+});
+
+export function ReportPill({
+  value,
+  label,
+}: Readonly<{
+  value: string;
+  label?: string;
+}>) {
+  const tone = toneByStatus[value] ?? 'neutral';
+
+  return (
+    <View style={[stylesForTone.base, stylesForTone[tone]]}>
+      <Text style={stylesForTone.text}>{label ?? labelize(value)}</Text>
+    </View>
+  );
+}
+
+export function ReportPillRow({
+  items,
+}: Readonly<{
+  items: { value: string; label?: string }[];
+}>) {
+  return (
+    <View style={styles.row}>
+      {items.map((item) => (
+        <ReportPill key={`${item.value}-${item.label ?? ''}`} label={item.label} value={item.value} />
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+});

--- a/apps/mobile/app/lib/api.ts
+++ b/apps/mobile/app/lib/api.ts
@@ -20,6 +20,10 @@ type ApiErrorPayload = {
   };
 };
 
+type AuthorizedInit = RequestInit & {
+  contentType?: string | null;
+};
+
 const readJsonPayload = async <T>(response: Response): Promise<(T & ApiErrorPayload) | null> => {
   const text = await response.text();
   if (!text) {
@@ -47,17 +51,36 @@ export const apiFetch = async <T>(path: string, init?: RequestInit): Promise<T> 
   return (payload ?? {}) as T;
 };
 
+export const authorizedFetch = async (
+  path: string,
+  accessToken: string,
+  init?: AuthorizedInit,
+): Promise<Response> => {
+  const { contentType = 'application/json', headers, ...rest } = init ?? {};
+
+  const mergedHeaders = new Headers(headers ?? {});
+  mergedHeaders.set('Authorization', `Bearer ${accessToken}`);
+  if (contentType) {
+    mergedHeaders.set('Content-Type', contentType);
+  }
+
+  return fetch(`${apiBaseUrl}${path}`, {
+    ...rest,
+    headers: mergedHeaders,
+  });
+};
+
 export const authorizedApiFetch = async <T>(
   path: string,
   accessToken: string,
-  init?: RequestInit,
+  init?: AuthorizedInit,
 ): Promise<T> => {
-  return apiFetch<T>(path, {
-    ...init,
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${accessToken}`,
-      ...(init?.headers ?? {}),
-    },
-  });
+  const response = await authorizedFetch(path, accessToken, init);
+  const payload = await readJsonPayload<T>(response);
+
+  if (!response.ok) {
+    throw new Error(toErrorMessage(payload, 'Request failed'));
+  }
+
+  return (payload ?? {}) as T;
 };


### PR DESCRIPTION
- This completes the mobile reporting issues by turning image selection into a real upload flow and tightening the report-submission UX around validation, locking, and submission feedback.
- Mobile now creates media drafts, uploads images before final report creation, and surfaces clear submission/anchor states using shared metadata pills across list and detail views.
- The work stays additive and backend-compatible: it uses the existing media and reports endpoints without changing server contracts, while making the citizen mobile reporting flow significantly closer to MVP-ready.

closes #129
closes #130
closes #131 
closes #132