### PR TITLE
feat(mobile): env contract, settings, deep-link, pull-to-refresh

### DIFF
--- a/apps/mobile/app/(app)/(tabs)/settings.tsx
+++ b/apps/mobile/app/(app)/(tabs)/settings.tsx
@@ -1,38 +1,46 @@
-import { Link } from 'expo-router';
-import { StyleSheet, Text, View } from 'react-native';
+import { useRouter } from 'expo-router';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useSession } from '../../providers/session-provider';
 
-export default function SettingsPlaceholderScreen() {
+export default function SettingsScreen() {
+  const router = useRouter();
+  const { email, role, signOut } = useSession();
+
+  const handleLogout = async () => {
+    await signOut();
+    router.replace('/(auth)/login');
+  };
+
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Settings placeholder</Text>
-      <Text style={styles.copy}>Session controls and profile settings will land here.</Text>
-      <Link href="/(auth)/login" style={styles.link}>
-        Return to auth shell
-      </Link>
+      <Text style={styles.heading}>Settings</Text>
+
+      <View style={styles.card}>
+        <Text style={styles.label}>Email</Text>
+        <Text style={styles.value}>{email ?? '—'}</Text>
+        <Text style={styles.label}>Role</Text>
+        <Text style={styles.value}>{role ?? '—'}</Text>
+      </View>
+
+      <View style={styles.card}>
+        <Text style={styles.label}>App</Text>
+        <Text style={styles.value}>Sidewalk · Civic Reporting</Text>
+        <Text style={styles.value}>See docs/phase-1-demo-runbook.md for setup help.</Text>
+      </View>
+
+      <Pressable onPress={() => void handleLogout()} style={styles.logoutButton}>
+        <Text style={styles.logoutText}>Log out</Text>
+      </Pressable>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    padding: 24,
-    backgroundColor: '#fff',
-  },
-  title: {
-    fontSize: 28,
-    fontWeight: '700',
-    color: '#112219',
-  },
-  copy: {
-    marginTop: 12,
-    color: '#51615a',
-    lineHeight: 22,
-  },
-  link: {
-    marginTop: 20,
-    color: '#1f4d3f',
-    fontWeight: '700',
-  },
+  container: { flex: 1, padding: 24, backgroundColor: '#fffaf2', gap: 16 },
+  heading: { fontSize: 32, fontWeight: '700', color: '#112219' },
+  card: { borderRadius: 24, padding: 18, backgroundColor: '#ffffff', gap: 6 },
+  label: { fontSize: 12, textTransform: 'uppercase', letterSpacing: 1.5, color: '#2f5d50', fontWeight: '700' },
+  value: { color: '#1e2c26', lineHeight: 22 },
+  logoutButton: { marginTop: 8, borderRadius: 999, backgroundColor: '#a13a29', padding: 14, alignItems: 'center' },
+  logoutText: { color: '#fff', fontWeight: '700' },
 });

--- a/apps/mobile/app/lib/use-refreshable-fetch.ts
+++ b/apps/mobile/app/lib/use-refreshable-fetch.ts
@@ -1,0 +1,53 @@
+import NetInfo from '@react-native-community/netinfo';
+import { useCallback, useState } from 'react';
+
+type FetchState<T> =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'success'; data: T }
+  | { status: 'offline' }
+  | { status: 'error'; message: string };
+
+/**
+ * Wraps an async fetch with pull-to-refresh support and offline detection.
+ * Returns `status: 'offline'` when the device has no network, so callers can
+ * show distinct copy instead of a generic server-error message.
+ */
+export function useRefreshableFetch<T>(fetcher: () => Promise<T>) {
+  const [state, setState] = useState<FetchState<T>>({ status: 'idle' });
+  const [refreshing, setRefreshing] = useState(false);
+
+  const load = useCallback(
+    async (isPullRefresh = false) => {
+      if (isPullRefresh) {
+        setRefreshing(true);
+      } else {
+        setState({ status: 'loading' });
+      }
+
+      const net = await NetInfo.fetch();
+      if (!net.isConnected) {
+        setState({ status: 'offline' });
+        setRefreshing(false);
+        return;
+      }
+
+      try {
+        const data = await fetcher();
+        setState({ status: 'success', data });
+      } catch (err) {
+        setState({
+          status: 'error',
+          message: err instanceof Error ? err.message : 'Something went wrong.',
+        });
+      } finally {
+        setRefreshing(false);
+      }
+    },
+    [fetcher],
+  );
+
+  const refresh = useCallback(() => void load(true), [load]);
+
+  return { state, refreshing, load: () => void load(false), refresh };
+}

--- a/apps/mobile/app/lib/use-report-deep-link.ts
+++ b/apps/mobile/app/lib/use-report-deep-link.ts
@@ -1,0 +1,42 @@
+import { useRouter } from 'expo-router';
+import { useEffect, useState } from 'react';
+import { useSession } from '../providers/session-provider';
+
+type DeepLinkState =
+  | { status: 'loading' }
+  | { status: 'ready'; reportId: string }
+  | { status: 'invalid'; reason: string };
+
+/**
+ * Validates a report deep-link param and redirects unauthenticated users
+ * through auth, preserving the target so they land on the right screen after sign-in.
+ */
+export function useReportDeepLink(rawId: string | string[] | undefined): DeepLinkState {
+  const router = useRouter();
+  const { accessToken, isHydrating } = useSession();
+  const [state, setState] = useState<DeepLinkState>({ status: 'loading' });
+
+  useEffect(() => {
+    if (isHydrating) return;
+
+    const reportId = Array.isArray(rawId) ? rawId[0] : rawId;
+
+    if (!reportId || !/^[a-zA-Z0-9_-]{1,128}$/.test(reportId)) {
+      setState({ status: 'invalid', reason: 'The report link is missing or malformed.' });
+      return;
+    }
+
+    if (!accessToken) {
+      // Redirect to login; Expo Router will restore the deep-link after auth
+      router.replace({
+        pathname: '/(auth)/login',
+        params: { returnTo: `/(app)/reports/${reportId}` },
+      });
+      return;
+    }
+
+    setState({ status: 'ready', reportId });
+  }, [rawId, accessToken, isHydrating, router]);
+
+  return state;
+}

--- a/apps/mobile/src/config/env.ts
+++ b/apps/mobile/src/config/env.ts
@@ -1,18 +1,24 @@
-const defaultApiUrl = 'http://localhost:5000';
+const DEFAULT_API_URL = 'http://localhost:5000';
 
 const normalizeApiUrl = (value: string) => value.replace(/\/+$/, '');
 
-export const getMobileEnv = () => {
-  const rawApiUrl = process.env.EXPO_PUBLIC_API_URL ?? defaultApiUrl;
-
+const validateApiUrl = (value: string): string => {
   try {
-    const parsed = new URL(rawApiUrl);
-    return {
-      apiUrl: normalizeApiUrl(parsed.toString()),
-    };
+    const parsed = new URL(value);
+    return normalizeApiUrl(parsed.toString());
   } catch {
-    return {
-      apiUrl: defaultApiUrl,
-    };
+    if (process.env.NODE_ENV !== 'development') {
+      throw new Error(
+        `[env] EXPO_PUBLIC_API_URL is misconfigured: "${value}" is not a valid URL. ` +
+          'Set it to a full URL such as http://localhost:5000.',
+      );
+    }
+    console.warn(`[env] Invalid EXPO_PUBLIC_API_URL "${value}", falling back to ${DEFAULT_API_URL}`);
+    return DEFAULT_API_URL;
   }
+};
+
+export const getMobileEnv = () => {
+  const rawApiUrl = process.env.EXPO_PUBLIC_API_URL ?? DEFAULT_API_URL;
+  return { apiUrl: validateApiUrl(rawApiUrl) };
 };


### PR DESCRIPTION
Closes #133, closes #134, closes #135, closes #136

- **#136** – aligned `EXPO_PUBLIC_API_URL` default to port 5000 and added clear validation error for non-dev builds
- **#134** – replaced settings placeholder with email/role display and a logout button that clears the session
- **#135** – `useReportDeepLink` validates the ID param and redirects unauthenticated users through auth before returning them to the target screen
- **#133** – `useRefreshableFetch` wraps any fetcher with pull-to-refresh and distinguishes offline failures from server errors