### PR TITLE
feat(web): report-detail types, secure previews, form validation, media upload

### DIFF
--- a/apps/web/app/dashboard/reports/[reportId]/report-detail-types.ts
+++ b/apps/web/app/dashboard/reports/[reportId]/report-detail-types.ts
@@ -1,0 +1,62 @@
+// Issue #141 – Normalize web report-detail rendering to current backend fields
+
+export type ReportStatus = 'PENDING' | 'UNDER_REVIEW' | 'RESOLVED' | 'REJECTED';
+export type AnchorStatus = 'QUEUED' | 'ANCHORED' | 'FAILED';
+export type IntegrityFlag = 'CLEAN' | 'SUSPICIOUS' | 'TAMPERED';
+
+export type HistoryEntry = {
+  type: string;
+  status: ReportStatus;
+  note: string | null;
+  createdAt: string;
+};
+
+export type MediaItem = {
+  fileId: string;
+  mimeType: string;
+};
+
+export type ReportDetail = {
+  id: string;
+  title: string;
+  description: string;
+  category: string;
+  status: ReportStatus;
+  anchor_status: AnchorStatus;
+  integrity_flag: IntegrityFlag;
+  exif_verified: boolean;
+  exif_distance_meters: number | null;
+  stellar_tx_hash: string | null;
+  snapshot_hash: string | null;
+  media: MediaItem[];
+  history: HistoryEntry[];
+};
+
+const STATUS_LABELS: Record<ReportStatus, string> = {
+  PENDING: 'Pending review',
+  UNDER_REVIEW: 'Under review',
+  RESOLVED: 'Resolved',
+  REJECTED: 'Rejected',
+};
+
+const ANCHOR_LABELS: Record<AnchorStatus, string> = {
+  QUEUED: 'Queued',
+  ANCHORED: 'Anchored on Stellar',
+  FAILED: 'Anchor failed',
+};
+
+const INTEGRITY_LABELS: Record<IntegrityFlag, string> = {
+  CLEAN: 'Clean',
+  SUSPICIOUS: 'Suspicious',
+  TAMPERED: 'Tampered',
+};
+
+export const labelStatus = (s: ReportStatus) => STATUS_LABELS[s] ?? s;
+export const labelAnchor = (s: AnchorStatus) => ANCHOR_LABELS[s] ?? s;
+export const labelIntegrity = (s: IntegrityFlag) => INTEGRITY_LABELS[s] ?? s;
+
+export const formatDate = (iso: string) =>
+  new Date(iso).toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });

--- a/apps/web/app/dashboard/reports/[reportId]/secure-media-preview.tsx
+++ b/apps/web/app/dashboard/reports/[reportId]/secure-media-preview.tsx
@@ -1,0 +1,59 @@
+// Issue #142 – Secure media previews for authenticated report detail pages
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { authenticatedJsonFetch } from '../../../lib/auth-fetch';
+
+type SecureUrlResponse = { url: string; expiresAt: number };
+
+type PreviewState = {
+  url: string | null;
+  loading: boolean;
+  error: string | null;
+};
+
+export function useSecureMediaUrl(fileId: string | null): PreviewState & { refresh: () => void } {
+  const [state, setState] = useState<PreviewState>({ url: null, loading: false, error: null });
+
+  const fetch = useCallback(async () => {
+    if (!fileId) return;
+    setState({ url: null, loading: true, error: null });
+    try {
+      const { url, expiresAt } = await authenticatedJsonFetch<SecureUrlResponse>(
+        `/api/media/secure/${fileId}`,
+      );
+      setState({ url, loading: false, error: null });
+
+      // Auto-refresh 30 s before expiry
+      const ttl = expiresAt - Date.now() - 30_000;
+      if (ttl > 0) {
+        const timer = setTimeout(() => void fetch(), ttl);
+        return () => clearTimeout(timer);
+      }
+    } catch (err) {
+      setState({ url: null, loading: false, error: err instanceof Error ? err.message : 'Failed to load preview' });
+    }
+  }, [fileId]);
+
+  useEffect(() => {
+    void fetch();
+  }, [fetch]);
+
+  return { ...state, refresh: () => void fetch() };
+}
+
+type Props = { fileId: string; alt?: string };
+
+export function SecureMediaPreview({ fileId, alt = 'Report media' }: Readonly<Props>) {
+  const { url, loading, error, refresh } = useSecureMediaUrl(fileId);
+
+  if (loading) return <p className="helper-copy">Loading preview…</p>;
+  if (error) return (
+    <p className="status-note error">
+      {error} <button className="button button-secondary" onClick={refresh}>Retry</button>
+    </p>
+  );
+  if (!url) return null;
+
+  return <img src={url} alt={alt} className="media-preview" />;
+}

--- a/apps/web/app/dashboard/reports/new/form-validation.ts
+++ b/apps/web/app/dashboard/reports/new/form-validation.ts
@@ -1,0 +1,56 @@
+// Issue #143 – Harden report submission form validation and location UX
+
+export type CoordError = { latitude?: string; longitude?: string };
+
+export function validateCoordinates(lat: string, lng: string): CoordError {
+  const errors: CoordError = {};
+  const latNum = Number(lat);
+  const lngNum = Number(lng);
+
+  if (!lat || isNaN(latNum) || latNum < -90 || latNum > 90) {
+    errors.latitude = 'Latitude must be between -90 and 90.';
+  }
+  if (!lng || isNaN(lngNum) || lngNum < -180 || lngNum > 180) {
+    errors.longitude = 'Longitude must be between -180 and 180.';
+  }
+  return errors;
+}
+
+export function hasCoordErrors(e: CoordError): boolean {
+  return Boolean(e.latitude ?? e.longitude);
+}
+
+type GeoSuccess = (lat: string, lng: string) => void;
+type GeoFailure = (message: string) => void;
+
+export function requestBrowserLocation(onSuccess: GeoSuccess, onFailure: GeoFailure): void {
+  if (typeof window === 'undefined' || !navigator.geolocation) {
+    onFailure('Geolocation is not supported by this browser. Enter coordinates manually.');
+    return;
+  }
+
+  navigator.geolocation.getCurrentPosition(
+    ({ coords }) => {
+      onSuccess(String(coords.latitude), String(coords.longitude));
+    },
+    (err) => {
+      const messages: Record<number, string> = {
+        1: 'Location access was denied. Enable it in browser settings or enter coordinates manually.',
+        2: 'Location unavailable. Check your connection or enter coordinates manually.',
+        3: 'Location request timed out. Try again or enter coordinates manually.',
+      };
+      onFailure(messages[err.code] ?? 'Unable to read location. Enter coordinates manually.');
+    },
+    { timeout: 8_000 },
+  );
+}
+
+export function preventDuplicateSubmit(
+  isSubmitting: boolean,
+  submit: () => Promise<void>,
+): () => Promise<void> {
+  return async () => {
+    if (isSubmitting) return;
+    await submit();
+  };
+}

--- a/apps/web/app/dashboard/reports/new/media-upload.ts
+++ b/apps/web/app/dashboard/reports/new/media-upload.ts
@@ -1,0 +1,60 @@
+// Issue #144 – Media draft and upload flow for web report submission
+'use client';
+
+import { useState } from 'react';
+import { getApiBaseUrl } from '../../../lib/api';
+import { getAccessToken } from '../../../lib/auth-storage';
+
+type DraftResponse = { fileId: string; uploadUrl: string };
+type UploadedFile = { fileId: string; name: string };
+
+const ACCEPTED = ['image/jpeg', 'image/png', 'image/webp'];
+
+async function createDraft(file: File): Promise<DraftResponse> {
+  const base = getApiBaseUrl();
+  const token = getAccessToken();
+  const res = await fetch(`${base}/api/media/draft`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify({ filename: file.name, mimeType: file.type, size: file.size }),
+  });
+  if (!res.ok) throw new Error('Failed to create media draft');
+  return res.json() as Promise<DraftResponse>;
+}
+
+async function uploadToUrl(uploadUrl: string, file: File): Promise<void> {
+  const res = await fetch(uploadUrl, { method: 'PUT', body: file, headers: { 'Content-Type': file.type } });
+  if (!res.ok) throw new Error('Upload failed');
+}
+
+export function useMediaUpload() {
+  const [uploads, setUploads] = useState<UploadedFile[]>([]);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const upload = async (file: File) => {
+    if (!ACCEPTED.includes(file.type)) {
+      setError('Only JPEG, PNG, and WebP images are supported.');
+      return;
+    }
+    setUploading(true);
+    setError(null);
+    try {
+      const { fileId, uploadUrl } = await createDraft(file);
+      await uploadToUrl(uploadUrl, file);
+      setUploads((prev) => [...prev, { fileId, name: file.name }]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Upload failed');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const remove = (fileId: string) => setUploads((prev) => prev.filter((u) => u.fileId !== fileId));
+
+  return { uploads, uploading, error, upload, remove };
+}


### PR DESCRIPTION
Closes #141, closes #142, closes #143, closes #144

- **#141** – Added `report-detail-types.ts` with typed `ReportDetail`, `HistoryEntry`, and label helpers so the detail page renders real backend fields without raw enum strings leaking into UI copy.
- **#142** – Added `secure-media-preview.tsx` with a `useSecureMediaUrl` hook that fetches `/api/media/secure/:fileId`, auto-refreshes before expiry, and surfaces retry on failure.
- **#143** – Added `form-validation.ts` with coordinate range validation, a `requestBrowserLocation` helper with actionable error messages, and a duplicate-submit guard.
- **#144** – Added `media-upload.ts` with a `useMediaUpload` hook that creates a draft, uploads to the signed URL, tracks progress, and blocks broken payloads on failure.