### PR TITLE
fix(web): API base URL, role-aware dashboard, report types, pagination

### DIFF
--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -1,28 +1,45 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { getStoredRole } from '../lib/auth-storage';
+
+const citizenLinks = [
+  { href: '/dashboard/reports/new', label: 'Submit a report' },
+  { href: '/dashboard/reports', label: 'My reports' },
+];
+
+const agencyLinks = [
+  { href: '/dashboard/reports', label: 'Reports queue' },
+  { href: '/dashboard/admin', label: 'Admin panel' },
+];
+
 export default function DashboardPage() {
+  const [role, setRole] = useState<string | null>(null);
+
+  useEffect(() => {
+    setRole(getStoredRole());
+  }, []);
+
+  const isAgency = role === 'agency' || role === 'admin';
+  const links = isAgency ? agencyLinks : citizenLinks;
+  const heading = isAgency ? 'Agency workspace' : 'Citizen workspace';
+
   return (
     <main className="page-shell">
       <section className="hero compact">
         <p className="eyebrow">Dashboard</p>
-        <h1>Authenticated workspace.</h1>
-        <p className="lede">
-          This protected shell confirms web sessions can be restored through the refresh
-          cookie flow before additional citizen or admin dashboards land.
-        </p>
+        <h1>{heading}</h1>
       </section>
 
       <section className="surface-grid">
-        <article className="surface-card">
-          <h2>Session guard</h2>
-          <p>Protected routes redirect back to OTP login when no access token or refresh path exists.</p>
-        </article>
-        <article className="surface-card">
-          <h2>Reports</h2>
-          <p>Open the reports workspace to submit new reports or inspect the authenticated list and detail flows.</p>
-        </article>
-        <article className="surface-card">
-          <h2>Ready for expansion</h2>
-          <p>This route can host report queues and detail screens without changing the auth contract.</p>
-        </article>
+        {links.map(({ href, label }) => (
+          <article className="surface-card" key={href}>
+            <Link className="button button-primary" href={href}>
+              {label}
+            </Link>
+          </article>
+        ))}
       </section>
     </main>
   );

--- a/apps/web/app/dashboard/reports/reports-list.tsx
+++ b/apps/web/app/dashboard/reports/reports-list.tsx
@@ -1,122 +1,96 @@
 'use client';
 
 import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { authenticatedJsonFetch } from '../../lib/auth-fetch';
 
 type ReportSummary = {
-  id: string;
+  _id: string;
   title: string;
   category: string;
   status: string;
-  anchor_status: string;
-  integrity_flag: string;
-  created_at: string;
+  anchorStatus: string;
+  integrityFlag: string;
+  createdAt: string;
 };
 
-type ReportListResponse = {
-  page: number;
-  pageSize: number;
-  total: number;
-  data: ReportSummary[];
-};
+type Pagination = { page: number; pageSize: number; total: number; totalPages: number };
+type ReportListResponse = { data: ReportSummary[]; pagination: Pagination };
 
 const statusOptions = ['ALL', 'PENDING', 'ACKNOWLEDGED', 'RESOLVED', 'REJECTED', 'ESCALATED'];
-const categoryOptions = [
-  'ALL',
-  'INFRASTRUCTURE',
-  'SANITATION',
-  'SAFETY',
-  'LIGHTING',
-  'TRANSPORT',
-  'DRAINAGE',
-  'UTILITIES',
-  'TRAFFIC',
-  'OTHER',
+const categoryOptions = ['ALL', 'INFRASTRUCTURE', 'SANITATION', 'SAFETY', 'LIGHTING', 'TRANSPORT', 'DRAINAGE', 'UTILITIES', 'TRAFFIC', 'OTHER'];
+const sortOptions = [
+  { value: 'createdAt:desc', label: 'Newest first' },
+  { value: 'createdAt:asc', label: 'Oldest first' },
+  { value: 'status:asc', label: 'Status A–Z' },
 ];
 
 export function ReportsList() {
-  const [status, setStatus] = useState('ALL');
-  const [category, setCategory] = useState('ALL');
+  const router = useRouter();
+  const params = useSearchParams();
+
+  const status = params.get('status') ?? 'ALL';
+  const category = params.get('category') ?? 'ALL';
+  const sort = params.get('sort') ?? 'createdAt:desc';
+  const page = Number(params.get('page') ?? '1');
+
   const [reports, setReports] = useState<ReportSummary[]>([]);
+  const [pagination, setPagination] = useState<Pagination | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
+  const push = (updates: Record<string, string>) => {
+    const next = new URLSearchParams(params.toString());
+    for (const [k, v] of Object.entries(updates)) {
+      if (v === 'ALL' || v === '') next.delete(k);
+      else next.set(k, v);
+    }
+    if (updates.page === undefined) next.set('page', '1');
+    router.push(`?${next.toString()}`);
+  };
+
   useEffect(() => {
     let cancelled = false;
+    setIsLoading(true);
+    setError(null);
 
-    const loadReports = async () => {
-      setIsLoading(true);
-      setError(null);
+    const [sortField, sortDir] = sort.split(':');
+    const query = new URLSearchParams({ page: String(page), pageSize: '12', sortField: sortField ?? 'createdAt', sortDir: sortDir ?? 'desc' });
+    if (status !== 'ALL') query.set('status', status);
+    if (category !== 'ALL') query.set('category', category);
 
-      const params = new URLSearchParams({
-        page: '1',
-        pageSize: '12',
-      });
+    authenticatedJsonFetch<ReportListResponse>(`/api/reports?${query.toString()}`)
+      .then((payload) => {
+        if (!cancelled) { setReports(payload.data); setPagination(payload.pagination); }
+      })
+      .catch((err) => {
+        if (!cancelled) { setError(err instanceof Error ? err.message : 'Unable to load reports'); setReports([]); }
+      })
+      .finally(() => { if (!cancelled) setIsLoading(false); });
 
-      if (status !== 'ALL') {
-        params.set('status', status);
-      }
-
-      if (category !== 'ALL') {
-        params.set('category', category);
-      }
-
-      try {
-        const payload = await authenticatedJsonFetch<ReportListResponse>(
-          `/api/reports?${params.toString()}`,
-        );
-
-        if (!cancelled) {
-          setReports(payload.data);
-        }
-      } catch (loadError) {
-        if (!cancelled) {
-          setError(loadError instanceof Error ? loadError.message : 'Unable to load reports');
-          setReports([]);
-        }
-      } finally {
-        if (!cancelled) {
-          setIsLoading(false);
-        }
-      }
-    };
-
-    void loadReports();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [category, status]);
+    return () => { cancelled = true; };
+  }, [status, category, sort, page]);
 
   return (
     <>
       <section className="auth-card filter-row">
-        <label className="field">
-          <span>Status</span>
-          <select value={status} onChange={(event) => setStatus(event.target.value)}>
-            {statusOptions.map((option) => (
-              <option key={option} value={option}>
-                {option}
-              </option>
-            ))}
+        <label className="field"><span>Status</span>
+          <select value={status} onChange={(e) => push({ status: e.target.value })}>
+            {statusOptions.map((o) => <option key={o} value={o}>{o}</option>)}
           </select>
         </label>
-
-        <label className="field">
-          <span>Category</span>
-          <select value={category} onChange={(event) => setCategory(event.target.value)}>
-            {categoryOptions.map((option) => (
-              <option key={option} value={option}>
-                {option}
-              </option>
-            ))}
+        <label className="field"><span>Category</span>
+          <select value={category} onChange={(e) => push({ category: e.target.value })}>
+            {categoryOptions.map((o) => <option key={o} value={o}>{o}</option>)}
           </select>
         </label>
-
-        <Link className="button button-primary" href="/dashboard/reports/new">
-          Submit report
-        </Link>
+        <label className="field"><span>Sort</span>
+          <select value={sort} onChange={(e) => push({ sort: e.target.value })}>
+            {sortOptions.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+          </select>
+        </label>
+        <Link className="button button-primary" href="/dashboard/reports/new">Submit report</Link>
       </section>
 
       {error ? <p className="status-note error">{error}</p> : null}
@@ -124,28 +98,28 @@ export function ReportsList() {
 
       <section className="surface-grid report-grid">
         {reports.map((report) => (
-          <article className="surface-card" key={report.id}>
+          <article className="surface-card" key={report._id}>
             <p className="eyebrow">{report.category}</p>
             <h2>{report.title}</h2>
-            <p className="helper-copy">
-              {report.status} · {report.anchor_status}
-            </p>
-            <p className="helper-copy">
-              {new Date(report.created_at).toLocaleString()}
-            </p>
-            {report.integrity_flag !== 'NORMAL' ? (
-              <p className="status-note error">Integrity flag: {report.integrity_flag}</p>
-            ) : null}
-            <Link className="button button-secondary" href={`/dashboard/reports/${report.id}`}>
-              Open report
-            </Link>
+            <p className="helper-copy">{report.status} · {report.anchorStatus}</p>
+            <p className="helper-copy">{new Date(report.createdAt).toLocaleString()}</p>
+            {report.integrityFlag !== 'NORMAL' && <p className="status-note error">Integrity flag: {report.integrityFlag}</p>}
+            <Link className="button button-secondary" href={`/dashboard/reports/${report._id}`}>Open report</Link>
           </article>
         ))}
       </section>
 
-      {!isLoading && reports.length === 0 && !error ? (
+      {!isLoading && reports.length === 0 && !error && (
         <p className="helper-copy">No reports matched the current filters.</p>
-      ) : null}
+      )}
+
+      {pagination && pagination.totalPages > 1 && (
+        <nav className="filter-row">
+          <button disabled={page <= 1} onClick={() => push({ page: String(page - 1) })}>← Prev</button>
+          <span className="helper-copy">Page {page} of {pagination.totalPages}</span>
+          <button disabled={page >= pagination.totalPages} onClick={() => push({ page: String(page + 1) })}>Next →</button>
+        </nav>
+      )}
     </>
   );
 }

--- a/apps/web/app/lib/api.ts
+++ b/apps/web/app/lib/api.ts
@@ -1,4 +1,4 @@
-const fallbackApiBaseUrl = 'http://localhost:4000';
+const fallbackApiBaseUrl = 'http://localhost:3000';
 
 export const getApiBaseUrl = () =>
   (process.env.NEXT_PUBLIC_API_BASE_URL ?? fallbackApiBaseUrl).replace(/\/+$/, '');


### PR DESCRIPTION
closes #137, 
closes #138, 
closes #139, 
closes #140

- **#137** Fix fallback API base URL from port 4000 → 3000 so local auth/report flows work without hidden URL mismatches.
- **#138** Dashboard now reads the stored role and shows citizen (submit/history) or agency (queue/admin) links accordingly.
- **#139** `ReportsList` types updated to match the real API contract (`_id`, `createdAt`, `anchorStatus`, `integrityFlag`, nested `pagination`). Timestamps render correctly.
- **#140** Filters, sort, and page are persisted in the URL via `useSearchParams`/`router.push`. Pagination controls appear when `totalPages > 1`.