### PR TITLE
feat(web): public reports list, detail, map discovery, harden OTP

### DIFF
--- a/apps/web/app/auth/_components/verify-otp-form.tsx
+++ b/apps/web/app/auth/_components/verify-otp-form.tsx
@@ -6,7 +6,17 @@ import { FormEvent, useEffect, useState } from 'react';
 import { persistSession } from '../../lib/auth-storage';
 import { getApiBaseUrl } from '../../lib/api';
 
-const defaultDeviceId = 'web-browser';
+const CODE_PATTERN = /^\d{6}$/;
+const DISTRICT_PATTERN = /^[a-zA-Z0-9 _-]{2,64}$/;
+
+function classifyError(message: string): string {
+  if (/expired/i.test(message)) return 'Your OTP has expired. Request a new code.';
+  if (/invalid.*code|code.*invalid/i.test(message)) return 'Invalid code. Check the email and try again.';
+  if (/district/i.test(message)) return 'District value is not recognised by the server.';
+  if (/role/i.test(message)) return 'The selected role is not permitted for this account.';
+  if (/session|token/i.test(message)) return 'Session error. Please sign in again.';
+  return message;
+}
 
 export function VerifyOtpForm() {
   const router = useRouter();
@@ -18,18 +28,22 @@ export function VerifyOtpForm() {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   useEffect(() => {
-    if (typeof window === 'undefined') {
-      return;
-    }
-
-    const storedEmail = window.localStorage.getItem('sidewalk:auth-email');
-    if (storedEmail) {
-      setEmail(storedEmail);
-    }
+    const stored = typeof window !== 'undefined' ? window.localStorage.getItem('sidewalk:auth-email') : null;
+    if (stored) setEmail(stored);
   }, []);
+
+  const validate = (): string | null => {
+    if (!email) return 'Email is required.';
+    if (!CODE_PATTERN.test(code)) return 'Code must be exactly 6 digits.';
+    if (district && !DISTRICT_PATTERN.test(district)) return 'District contains invalid characters.';
+    return null;
+  };
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    const validationError = validate();
+    if (validationError) { setError(validationError); return; }
+
     setIsSubmitting(true);
     setError(null);
 
@@ -38,36 +52,19 @@ export function VerifyOtpForm() {
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          email,
-          code,
-          district: district || undefined,
-          role,
-          deviceId: defaultDeviceId,
-          clientType: 'web',
-        }),
+        body: JSON.stringify({ email, code, district: district.trim() || undefined, role, deviceId: 'web-browser', clientType: 'web' }),
       });
 
-      const payload = (await response.json()) as {
-        accessToken?: string;
-        expiresIn?: string;
-        error?: { message?: string };
-      };
+      const payload = (await response.json()) as { accessToken?: string; expiresIn?: string; error?: { message?: string } };
 
       if (!response.ok || !payload.accessToken) {
         throw new Error(payload.error?.message ?? 'Unable to verify OTP');
       }
 
-      persistSession({
-        accessToken: payload.accessToken,
-        email,
-        expiresIn: payload.expiresIn ?? '15m',
-        role,
-      });
-
+      persistSession({ accessToken: payload.accessToken, email, expiresIn: payload.expiresIn ?? '15m', role });
       router.replace('/dashboard');
-    } catch (submitError) {
-      setError(submitError instanceof Error ? submitError.message : 'Unable to verify OTP');
+    } catch (err) {
+      setError(classifyError(err instanceof Error ? err.message : 'Unable to verify OTP'));
     } finally {
       setIsSubmitting(false);
     }
@@ -78,32 +75,19 @@ export function VerifyOtpForm() {
       <form className="form-grid" onSubmit={handleSubmit}>
         <label className="field">
           <span>Email</span>
-          <input
-            autoComplete="email"
-            name="email"
-            type="email"
-            value={email}
-            onChange={(event) => setEmail(event.target.value)}
-            placeholder="citizen@example.com"
-            required
-          />
+          <input autoComplete="email" name="email" type="email" value={email}
+            onChange={(e) => setEmail(e.target.value)} placeholder="citizen@example.com" required />
         </label>
 
         <label className="field">
           <span>OTP Code</span>
-          <input
-            inputMode="numeric"
-            name="code"
-            value={code}
-            onChange={(event) => setCode(event.target.value)}
-            placeholder="123456"
-            required
-          />
+          <input inputMode="numeric" name="code" value={code} maxLength={6}
+            onChange={(e) => setCode(e.target.value.replace(/\D/g, ''))} placeholder="123456" required />
         </label>
 
         <label className="field">
           <span>Role</span>
-          <select value={role} onChange={(event) => setRole(event.target.value as 'CITIZEN' | 'AGENCY_ADMIN')}>
+          <select value={role} onChange={(e) => setRole(e.target.value as 'CITIZEN' | 'AGENCY_ADMIN')}>
             <option value="CITIZEN">Citizen</option>
             <option value="AGENCY_ADMIN">Agency admin</option>
           </select>
@@ -111,12 +95,7 @@ export function VerifyOtpForm() {
 
         <label className="field">
           <span>District</span>
-          <input
-            name="district"
-            value={district}
-            onChange={(event) => setDistrict(event.target.value)}
-            placeholder="Ikeja"
-          />
+          <input name="district" value={district} onChange={(e) => setDistrict(e.target.value)} placeholder="Ikeja" />
         </label>
 
         <button className="button button-primary" disabled={isSubmitting} type="submit">
@@ -124,7 +103,7 @@ export function VerifyOtpForm() {
         </button>
       </form>
 
-      {error ? <p className="status-note error">{error}</p> : null}
+      {error && <p className="status-note error">{error}</p>}
 
       <p className="helper-copy">
         Need a new code? <Link href="/auth/request-otp">Request OTP</Link>

--- a/apps/web/app/dashboard/map/map-discovery.tsx
+++ b/apps/web/app/dashboard/map/map-discovery.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import Link from 'next/link';
+import { FormEvent, useState } from 'react';
+import { authenticatedJsonFetch } from '../lib/auth-fetch';
+
+type MapReport = { _id: string; title: string; category: string; status: string; lat: number; lng: number };
+type MapQueryResponse = { data: MapReport[] };
+
+type QueryMode = 'radius' | 'bounds';
+
+export function MapDiscovery() {
+  const [mode, setMode] = useState<QueryMode>('radius');
+  const [lat, setLat] = useState('');
+  const [lng, setLng] = useState('');
+  const [radius, setRadius] = useState('1000');
+  const [minLat, setMinLat] = useState('');
+  const [maxLat, setMaxLat] = useState('');
+  const [minLng, setMinLng] = useState('');
+  const [maxLng, setMaxLng] = useState('');
+  const [results, setResults] = useState<MapReport[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setIsLoading(true);
+
+    try {
+      const q = new URLSearchParams();
+      if (mode === 'radius') {
+        q.set('lat', lat); q.set('lng', lng); q.set('radius', radius);
+      } else {
+        q.set('minLat', minLat); q.set('maxLat', maxLat);
+        q.set('minLng', minLng); q.set('maxLng', maxLng);
+      }
+      const payload = await authenticatedJsonFetch<MapQueryResponse>(`/api/reports/map?${q.toString()}`);
+      setResults(payload.data);
+      if (payload.data.length === 0) setError('No reports found in this area.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Map query failed');
+      setResults([]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <section className="auth-card">
+        <form className="form-grid" onSubmit={handleSubmit}>
+          <label className="field"><span>Query mode</span>
+            <select value={mode} onChange={(e) => setMode(e.target.value as QueryMode)}>
+              <option value="radius">Radius</option>
+              <option value="bounds">Bounds</option>
+            </select>
+          </label>
+
+          {mode === 'radius' ? (
+            <>
+              <label className="field"><span>Latitude</span><input required value={lat} onChange={(e) => setLat(e.target.value)} placeholder="6.5244" /></label>
+              <label className="field"><span>Longitude</span><input required value={lng} onChange={(e) => setLng(e.target.value)} placeholder="3.3792" /></label>
+              <label className="field"><span>Radius (m)</span><input required value={radius} onChange={(e) => setRadius(e.target.value)} /></label>
+            </>
+          ) : (
+            <>
+              <label className="field"><span>Min lat</span><input required value={minLat} onChange={(e) => setMinLat(e.target.value)} /></label>
+              <label className="field"><span>Max lat</span><input required value={maxLat} onChange={(e) => setMaxLat(e.target.value)} /></label>
+              <label className="field"><span>Min lng</span><input required value={minLng} onChange={(e) => setMinLng(e.target.value)} /></label>
+              <label className="field"><span>Max lng</span><input required value={maxLng} onChange={(e) => setMaxLng(e.target.value)} /></label>
+            </>
+          )}
+
+          <button className="button button-primary" disabled={isLoading} type="submit">
+            {isLoading ? 'Searching…' : 'Search area'}
+          </button>
+        </form>
+      </section>
+
+      {error && <p className="status-note error">{error}</p>}
+
+      <section className="surface-grid report-grid">
+        {results.map((r) => (
+          <article className="surface-card" key={r._id}>
+            <p className="eyebrow">{r.category}</p>
+            <h2>{r.title}</h2>
+            <p className="helper-copy">{r.status} · {r.lat.toFixed(4)}, {r.lng.toFixed(4)}</p>
+            <Link className="button button-secondary" href={`/dashboard/reports/${r._id}`}>Open report</Link>
+          </article>
+        ))}
+      </section>
+    </>
+  );
+}

--- a/apps/web/app/reports/[reportId]/public-report-detail.tsx
+++ b/apps/web/app/reports/[reportId]/public-report-detail.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { getApiBaseUrl } from '../../lib/api';
+
+type PublicReportDetail = {
+  _id: string;
+  title: string;
+  description: string;
+  category: string;
+  status: string;
+  anchor_status: string;
+  stellar_tx_hash: string | null;
+  location_summary: string | null;
+  history: Array<{ status: string; note: string | null; createdAt: string }>;
+};
+
+export function PublicReportDetail({ reportId }: Readonly<{ reportId: string }>) {
+  const [report, setReport] = useState<PublicReportDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetch(`${getApiBaseUrl()}/api/reports/public/${reportId}`)
+      .then((r) => {
+        if (r.status === 404) { setNotFound(true); return null; }
+        return r.json() as Promise<PublicReportDetail>;
+      })
+      .then((payload) => { if (!cancelled && payload) setReport(payload); })
+      .catch(() => { if (!cancelled) setError('Unable to load report'); });
+
+    return () => { cancelled = true; };
+  }, [reportId]);
+
+  if (notFound) return (
+    <section className="auth-card">
+      <p className="status-note error">Report not found.</p>
+      <Link className="button button-secondary" href="/reports">Back to reports</Link>
+    </section>
+  );
+
+  if (error) return <p className="status-note error">{error}</p>;
+  if (!report) return <p className="helper-copy">Loading report…</p>;
+
+  return (
+    <>
+      <section className="auth-card detail-grid">
+        <div>
+          <p className="eyebrow">{report.category}</p>
+          <h2>{report.title}</h2>
+          <p className="lede compact-copy">{report.description}</p>
+          {report.location_summary && <p className="helper-copy">📍 {report.location_summary}</p>}
+        </div>
+        <dl className="detail-list">
+          <div><dt>Status</dt><dd>{report.status}</dd></div>
+          <div><dt>Anchor</dt><dd>{report.anchor_status}</dd></div>
+          <div><dt>Stellar tx</dt><dd>{report.stellar_tx_hash ?? 'Pending'}</dd></div>
+        </dl>
+      </section>
+
+      <section className="auth-card">
+        <h2>Public history</h2>
+        {report.history.length === 0
+          ? <p className="helper-copy">No history yet.</p>
+          : (
+            <ol className="timeline-list">
+              {report.history.map((entry) => (
+                <li key={`${entry.status}-${entry.createdAt}`}>
+                  <strong>{entry.status}</strong>
+                  {entry.note && <p>{entry.note}</p>}
+                  <time>{new Date(entry.createdAt).toLocaleString()}</time>
+                </li>
+              ))}
+            </ol>
+          )}
+        <Link className="button button-secondary" href="/reports">Back to reports</Link>
+      </section>
+    </>
+  );
+}

--- a/apps/web/app/reports/public-reports-list.tsx
+++ b/apps/web/app/reports/public-reports-list.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { getApiBaseUrl } from '../lib/api';
+
+type PublicReport = { _id: string; title: string; category: string; status: string; createdAt: string };
+type Pagination = { page: number; totalPages: number };
+type PublicListResponse = { data: PublicReport[]; pagination: Pagination };
+
+const categoryOptions = ['ALL', 'INFRASTRUCTURE', 'SANITATION', 'SAFETY', 'LIGHTING', 'TRANSPORT', 'OTHER'];
+const statusOptions = ['ALL', 'PENDING', 'ACKNOWLEDGED', 'RESOLVED'];
+
+export function PublicReportsList() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const category = params.get('category') ?? 'ALL';
+  const status = params.get('status') ?? 'ALL';
+  const page = Number(params.get('page') ?? '1');
+
+  const [reports, setReports] = useState<PublicReport[]>([]);
+  const [pagination, setPagination] = useState<Pagination | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const push = (updates: Record<string, string>) => {
+    const next = new URLSearchParams(params.toString());
+    for (const [k, v] of Object.entries(updates)) {
+      if (v === 'ALL') next.delete(k); else next.set(k, v);
+    }
+    if (!updates.page) next.set('page', '1');
+    router.push(`?${next.toString()}`);
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    const q = new URLSearchParams({ page: String(page), pageSize: '12' });
+    if (category !== 'ALL') q.set('category', category);
+    if (status !== 'ALL') q.set('status', status);
+
+    fetch(`${getApiBaseUrl()}/api/reports/public?${q.toString()}`)
+      .then((r) => r.json() as Promise<PublicListResponse>)
+      .then((payload) => { if (!cancelled) { setReports(payload.data); setPagination(payload.pagination); } })
+      .catch(() => { if (!cancelled) setError('Unable to load reports'); })
+      .finally(() => { if (!cancelled) setIsLoading(false); });
+
+    return () => { cancelled = true; };
+  }, [category, status, page]);
+
+  return (
+    <>
+      <section className="auth-card filter-row">
+        <label className="field"><span>Category</span>
+          <select value={category} onChange={(e) => push({ category: e.target.value })}>
+            {categoryOptions.map((o) => <option key={o} value={o}>{o}</option>)}
+          </select>
+        </label>
+        <label className="field"><span>Status</span>
+          <select value={status} onChange={(e) => push({ status: e.target.value })}>
+            {statusOptions.map((o) => <option key={o} value={o}>{o}</option>)}
+          </select>
+        </label>
+      </section>
+
+      {error && <p className="status-note error">{error}</p>}
+      {isLoading && <p className="helper-copy">Loading reports…</p>}
+
+      <section className="surface-grid report-grid">
+        {reports.map((r) => (
+          <article className="surface-card" key={r._id}>
+            <p className="eyebrow">{r.category}</p>
+            <h2>{r.title}</h2>
+            <p className="helper-copy">{r.status} · {new Date(r.createdAt).toLocaleDateString()}</p>
+            <Link className="button button-secondary" href={`/reports/${r._id}`}>View report</Link>
+          </article>
+        ))}
+      </section>
+
+      {!isLoading && reports.length === 0 && !error && <p className="helper-copy">No reports found.</p>}
+
+      {pagination && pagination.totalPages > 1 && (
+        <nav className="filter-row">
+          <button disabled={page <= 1} onClick={() => push({ page: String(page - 1) })}>← Prev</button>
+          <span className="helper-copy">Page {page} of {pagination.totalPages}</span>
+          <button disabled={page >= pagination.totalPages} onClick={() => push({ page: String(page + 1) })}>Next →</button>
+        </nav>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
Adds the four Sprint-1 frontend-web deliverables.

- **#145** — Public reports landing page with category/status filters and URL-driven pagination, calling `/api/reports/public` without auth.
- **#146** — Public report detail page backed by `/api/reports/public/:reportId`; shows summary, location, anchor state, and public history; returns a not-found state for missing reports.
- **#147** — Map discovery page for authenticated users; supports radius and bounds query modes against `/api/reports/map`; shows empty-result and error states.
- **#148** — Hardened OTP verify form: client-side 6-digit code validation, district format check, and a `classifyError` helper that maps expired/invalid-code/role/district/session errors to readable messages.

Closes #145, Closes #146, Closes #147, Closes #148