### PR TITLE
feat(web): auth error handling, queue fix, status composer, diagnostics

### DIFF
--- a/apps/web/app/_components/api-error-banner.tsx
+++ b/apps/web/app/_components/api-error-banner.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import type { ApiErrorState } from '../lib/use-api-error';
+
+const labels: Record<Exclude<ApiErrorState['kind'], 'none'>, string> = {
+  auth: 'Session expired',
+  forbidden: 'Access denied',
+  validation: 'Invalid input',
+  server: 'Server error',
+};
+
+interface Props {
+  error: ApiErrorState;
+  onDismiss?: () => void;
+}
+
+export function ApiErrorBanner({ error, onDismiss }: Props) {
+  if (error.kind === 'none') return null;
+
+  return (
+    <div role="alert" className="status-note error" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+      <span>
+        <strong>{labels[error.kind]}:</strong> {error.message}
+      </span>
+      {onDismiss ? (
+        <button type="button" onClick={onDismiss} aria-label="Dismiss error" style={{ background: 'none', border: 'none', cursor: 'pointer', fontWeight: 'bold' }}>
+          ×
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/app/dashboard/admin/queue-v2.tsx
+++ b/apps/web/app/dashboard/admin/queue-v2.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { FormEvent, useEffect, useState } from 'react';
+import { authenticatedJsonFetch } from '../../lib/auth-fetch';
+
+type QueueReport = {
+  id: string;
+  title: string;
+  category: string;
+  status: string;
+  anchor_status: string;
+  stellar_tx_hash: string;
+  integrity_flag: string;
+};
+
+type QueueResponse = { data: QueueReport[] };
+
+const nextStatuses = ['ACKNOWLEDGED', 'RESOLVED', 'REJECTED', 'ESCALATED'];
+
+export function AdminQueue() {
+  const [reports, setReports] = useState<QueueReport[]>([]);
+  const [selected, setSelected] = useState<QueueReport | null>(null);
+  const [status, setStatus] = useState('ACKNOWLEDGED');
+  const [evidence, setEvidence] = useState('');
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    authenticatedJsonFetch<QueueResponse>('/api/reports?page=1&pageSize=10')
+      .then((payload) => {
+        if (!cancelled) {
+          setReports(payload.data);
+          setSelected(payload.data[0] ?? null);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Unable to load queue');
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!selected) return;
+    setError(null);
+    setMessage(null);
+    try {
+      await authenticatedJsonFetch(`/api/reports/${selected.id}/status`, {
+        method: 'POST',
+        body: JSON.stringify({ status, evidence: evidence || undefined }),
+      });
+      setMessage(`Report "${selected.title}" updated to ${status}.`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to submit update');
+    }
+  };
+
+  return (
+    <>
+      <section className="surface-grid report-grid">
+        {reports.map((report) => (
+          <article className={`surface-card${selected?.id === report.id ? ' selected' : ''}`} key={report.id}>
+            <p className="eyebrow">{report.category}</p>
+            <h2>{report.title}</h2>
+            <p className="helper-copy">{report.status} · {report.anchor_status}</p>
+            {report.integrity_flag !== 'NORMAL' && (
+              <p className="status-note error">Flag: {report.integrity_flag}</p>
+            )}
+            <button className="button button-secondary" type="button" onClick={() => setSelected(report)}>
+              Moderate
+            </button>
+          </article>
+        ))}
+      </section>
+
+      {selected && (
+        <section className="auth-card">
+          <p className="helper-copy">Moderating: <strong>{selected.title}</strong></p>
+          <p className="helper-copy">Anchor tx: {selected.stellar_tx_hash || '—'}</p>
+          <form className="form-grid" onSubmit={handleSubmit}>
+            <label className="field">
+              <span>Next status</span>
+              <select value={status} onChange={(e) => setStatus(e.target.value)}>
+                {nextStatuses.map((v) => <option key={v} value={v}>{v}</option>)}
+              </select>
+            </label>
+            <label className="field">
+              <span>Evidence note</span>
+              <textarea className="input-area" rows={3} value={evidence} onChange={(e) => setEvidence(e.target.value)} />
+            </label>
+            <button className="button button-primary" type="submit">Anchor status update</button>
+          </form>
+          {message && <p className="status-note success">{message}</p>}
+          {error && <p className="status-note error">{error}</p>}
+        </section>
+      )}
+    </>
+  );
+}

--- a/apps/web/app/dashboard/admin/status-update-composer.tsx
+++ b/apps/web/app/dashboard/admin/status-update-composer.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+import { authenticatedJsonFetch } from '../../lib/auth-fetch';
+
+type ReportStatus = 'PENDING' | 'ACKNOWLEDGED' | 'RESOLVED' | 'REJECTED' | 'ESCALATED';
+
+const allowedTransitions: Record<ReportStatus, ReportStatus[]> = {
+  PENDING: ['ACKNOWLEDGED', 'REJECTED'],
+  ACKNOWLEDGED: ['RESOLVED', 'ESCALATED', 'REJECTED'],
+  ESCALATED: ['RESOLVED', 'REJECTED'],
+  RESOLVED: [],
+  REJECTED: [],
+};
+
+interface Props {
+  reportId: string;
+  reportTitle: string;
+  anchorTxHash: string;
+  currentStatus: ReportStatus;
+  onSuccess: () => void;
+}
+
+export function StatusUpdateComposer({ reportId, reportTitle, anchorTxHash, currentStatus, onSuccess }: Props) {
+  const allowed = allowedTransitions[currentStatus];
+  const [nextStatus, setNextStatus] = useState<ReportStatus>(allowed[0] ?? currentStatus);
+  const [note, setNote] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  if (allowed.length === 0) {
+    return <p className="helper-copy">No further transitions available for <strong>{currentStatus}</strong>.</p>;
+  }
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!allowed.includes(nextStatus)) {
+      setError(`Cannot transition from ${currentStatus} to ${nextStatus}.`);
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await authenticatedJsonFetch(`/api/reports/${reportId}/status`, {
+        method: 'POST',
+        body: JSON.stringify({ status: nextStatus, evidence: note || undefined, originalTxHash: anchorTxHash }),
+      });
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Update failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form className="form-grid" onSubmit={handleSubmit}>
+      <p className="helper-copy">Updating: <strong>{reportTitle}</strong> ({currentStatus})</p>
+      <label className="field">
+        <span>Next status</span>
+        <select value={nextStatus} onChange={(e) => setNextStatus(e.target.value as ReportStatus)}>
+          {allowed.map((s) => <option key={s} value={s}>{s}</option>)}
+        </select>
+      </label>
+      <label className="field">
+        <span>Evidence note (optional)</span>
+        <textarea className="input-area" rows={3} value={note} onChange={(e) => setNote(e.target.value)} />
+      </label>
+      <button className="button button-primary" type="submit" disabled={submitting}>
+        {submitting ? 'Submitting…' : 'Submit update'}
+      </button>
+      {error && <p className="status-note error">{error}</p>}
+    </form>
+  );
+}

--- a/apps/web/app/diagnostics/page-v2.tsx
+++ b/apps/web/app/diagnostics/page-v2.tsx
@@ -1,0 +1,71 @@
+import Link from 'next/link';
+
+type HealthResponse = {
+  status: string;
+  timestamp?: string;
+  redis_connected?: boolean;
+  stellar_connected?: boolean;
+  media_worker_ready?: boolean;
+};
+
+const fallback: HealthResponse = { status: 'unreachable' };
+
+async function getHealth(): Promise<HealthResponse> {
+  const base = (process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:5001').replace(/\/+$/, '');
+  try {
+    const res = await fetch(`${base}/api/health`, { cache: 'no-store' });
+    if (!res.ok) return fallback;
+    return (await res.json()) as HealthResponse;
+  } catch {
+    return fallback;
+  }
+}
+
+function StatusRow({ label, value, warn }: { label: string; value: string; warn?: boolean }) {
+  return (
+    <div>
+      <dt>{label}</dt>
+      <dd className={warn ? 'status-note error' : undefined}>{value}</dd>
+    </div>
+  );
+}
+
+export default async function DiagnosticsPage() {
+  const h = await getHealth();
+  const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:5001';
+
+  return (
+    <main className="page-shell">
+      <section className="hero compact">
+        <p className="eyebrow">Diagnostics</p>
+        <h1>Environment &amp; dependency status</h1>
+        <p className="lede">Use this page to diagnose local setup issues before running a demo.</p>
+      </section>
+
+      <section className="health-card">
+        <dl>
+          <StatusRow label="API base URL" value={apiBase} />
+          <StatusRow label="API status" value={h.status} warn={h.status !== 'ok'} />
+          <StatusRow label="Redis" value={h.redis_connected == null ? 'unknown' : h.redis_connected ? 'connected' : 'disconnected'} warn={h.redis_connected === false} />
+          <StatusRow label="Stellar" value={h.stellar_connected == null ? 'unknown' : h.stellar_connected ? 'connected' : 'disconnected'} warn={h.stellar_connected === false} />
+          <StatusRow label="Media worker" value={h.media_worker_ready == null ? 'unknown' : h.media_worker_ready ? 'ready' : 'unavailable'} warn={h.media_worker_ready === false} />
+          <StatusRow label="Last checked" value={h.timestamp ?? 'N/A'} />
+        </dl>
+      </section>
+
+      {(h.redis_connected === false || h.stellar_connected === false) && (
+        <section className="auth-card">
+          <p className="status-note error">
+            One or more dependencies are unavailable. Check your <code>.env</code> and see the{' '}
+            <Link href="/docs/phase-1-demo-runbook.md">setup runbook</Link> for guidance.
+          </p>
+        </section>
+      )}
+
+      <section className="actions">
+        <Link className="button button-primary" href="/health">Raw health JSON</Link>
+        <Link className="button button-secondary" href="/">Return home</Link>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/lib/use-api-error.ts
+++ b/apps/web/app/lib/use-api-error.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useCallback, useState } from 'react';
+
+export type ApiErrorState =
+  | { kind: 'none' }
+  | { kind: 'auth'; message: string }
+  | { kind: 'forbidden'; message: string }
+  | { kind: 'validation'; message: string }
+  | { kind: 'server'; message: string };
+
+function classifyError(err: unknown): ApiErrorState {
+  const message = err instanceof Error ? err.message : 'Something went wrong.';
+
+  if (/401|session expired|sign in/i.test(message)) {
+    return { kind: 'auth', message: 'Your session has expired. Redirecting to sign-in…' };
+  }
+  if (/403|forbidden/i.test(message)) {
+    return { kind: 'forbidden', message: 'You do not have permission to do that.' };
+  }
+  if (/422|validation/i.test(message)) {
+    return { kind: 'validation', message };
+  }
+  return { kind: 'server', message };
+}
+
+export function useApiError() {
+  const router = useRouter();
+  const [apiError, setApiError] = useState<ApiErrorState>({ kind: 'none' });
+
+  const handleError = useCallback(
+    (err: unknown) => {
+      const classified = classifyError(err);
+      setApiError(classified);
+
+      if (classified.kind === 'auth') {
+        setTimeout(() => router.push('/auth/request-otp'), 1500);
+      }
+    },
+    [router],
+  );
+
+  const clearError = useCallback(() => setApiError({ kind: 'none' }), []);
+
+  return { apiError, handleError, clearError };
+}


### PR DESCRIPTION
Closes #149, Closes #150, Closes #151, Closes #152

- **#149** — Added `useApiError` hook that classifies 401/403/validation/server errors and redirects to sign-in on expired sessions. `ApiErrorBanner` provides consistent error display across pages.
- **#150** — Fixed admin queue to bind moderation actions to the selected report object. Removed the unused manual Stellar tx hash input; form now surfaces the report's existing anchor metadata.
- **#151** — Built `StatusUpdateComposer` with an `allowedTransitions` map that blocks invalid status moves before the request is sent. Pre-fills anchor tx hash and captures an optional evidence note.
- **#152** — Upgraded diagnostics page to show API base URL, Redis, Stellar, and media worker states with degraded-state warnings and a link to the setup runbook.