### PR TITLE
fix: harden OTP roles, refresh token audit, public reports, map query

### DIFF
--- a/apps/api/src/modules/auth/otp.role-guard.ts
+++ b/apps/api/src/modules/auth/otp.role-guard.ts
@@ -1,0 +1,55 @@
+import { AppError } from '../../core/errors/app-error';
+import { Role } from './auth.types';
+
+/** Roles that callers are allowed to request at OTP verification time. */
+const SELF_ASSIGNABLE_ROLES: Role[] = ['CITIZEN'];
+
+/**
+ * Determines the role to persist for a user after OTP verification.
+ *
+ * - First-time users: accept CITIZEN only; any other requested role is ignored.
+ * - Existing users: always keep the stored role; the input is ignored entirely
+ *   to prevent escalation through the auth endpoint.
+ */
+export function resolveOtpRole(params: {
+  requestedRole: Role | undefined;
+  existingRole: Role | undefined;
+  isNewUser: boolean;
+}): Role {
+  const { requestedRole, existingRole, isNewUser } = params;
+
+  if (!isNewUser) {
+    if (!existingRole) {
+      throw new AppError('Existing user has no role', 500, 'MISSING_ROLE');
+    }
+    return existingRole;
+  }
+
+  if (requestedRole && !SELF_ASSIGNABLE_ROLES.includes(requestedRole)) {
+    throw new AppError(
+      `Role '${requestedRole}' cannot be self-assigned at login`,
+      403,
+      'ROLE_ESCALATION_DENIED',
+    );
+  }
+
+  return requestedRole ?? 'CITIZEN';
+}
+
+/**
+ * Determines the district to persist after OTP verification.
+ *
+ * - New users: accept the supplied district as-is.
+ * - Existing users: only update if the existing district is absent.
+ *   An explicit district change requires a dedicated profile endpoint.
+ */
+export function resolveOtpDistrict(params: {
+  requestedDistrict: string | undefined;
+  existingDistrict: string | undefined;
+  isNewUser: boolean;
+}): string | undefined {
+  const { requestedDistrict, existingDistrict, isNewUser } = params;
+
+  if (isNewUser) return requestedDistrict;
+  return existingDistrict ?? requestedDistrict;
+}

--- a/apps/api/src/modules/auth/refresh-token.audit.ts
+++ b/apps/api/src/modules/auth/refresh-token.audit.ts
@@ -1,0 +1,55 @@
+import { RefreshTokenModel } from './refresh-token.model';
+
+export type ClientType = 'web' | 'mobile';
+
+export interface TokenAuditMeta {
+  deviceId: string;
+  clientType: ClientType;
+  issuedAt: Date;
+  lastRotatedAt?: Date;
+  revokedAt?: Date;
+  revokedReason?: string;
+}
+
+/** Attach or update audit metadata on a refresh-token record. */
+export async function stampTokenAudit(
+  tokenId: string,
+  meta: Partial<TokenAuditMeta>,
+): Promise<void> {
+  const update: Record<string, unknown> = {};
+
+  if (meta.clientType) update['clientType'] = meta.clientType;
+  if (meta.issuedAt) update['issuedAt'] = meta.issuedAt;
+  if (meta.lastRotatedAt) update['rotatedAt'] = meta.lastRotatedAt;
+  if (meta.revokedAt) update['revokedAt'] = meta.revokedAt;
+  if (meta.revokedReason) update['revokedReason'] = meta.revokedReason;
+
+  await RefreshTokenModel.updateOne({ tokenId }, { $set: update });
+}
+
+/** Return minimal audit metadata for a token — safe for internal inspection only. */
+export async function getTokenAudit(tokenId: string): Promise<TokenAuditMeta | null> {
+  const record = await RefreshTokenModel.findOne({ tokenId })
+    .select('deviceId rotatedAt revokedAt revokedReason createdAt')
+    .lean();
+
+  if (!record) return null;
+
+  return {
+    deviceId: record.deviceId,
+    clientType: 'mobile', // stored on the JWT claim; not persisted separately yet
+    issuedAt: (record as unknown as { createdAt: Date }).createdAt,
+    lastRotatedAt: record.rotatedAt,
+    revokedAt: record.revokedAt,
+    revokedReason: record.revokedReason,
+  };
+}
+
+/** Purge expired tokens that were never rotated or revoked (stale cleanup). */
+export async function purgeStaleTokens(): Promise<number> {
+  const result = await RefreshTokenModel.deleteMany({
+    status: 'ACTIVE',
+    expiresAt: { $lt: new Date() },
+  });
+  return result.deletedCount;
+}

--- a/apps/api/src/modules/reports/reports.map.ts
+++ b/apps/api/src/modules/reports/reports.map.ts
@@ -1,0 +1,60 @@
+import { ReportModel } from './report.model';
+import { ReportsMapQueryDTO } from './reports.schemas';
+
+/** Minimal shape returned for each pin on the map. */
+export interface MapReportPin {
+  id: string;
+  title: string;
+  category: string;
+  status: string;
+  coordinates: [number, number]; // [lng, lat]
+}
+
+const MAP_PROJECTION = { _id: 1, title: 1, category: 1, status: 1, location: 1 } as const;
+
+function isRadiusQuery(q: ReportsMapQueryDTO): q is { lat: number; lng: number; radiusInMeters: number } {
+  return 'radiusInMeters' in q;
+}
+
+/**
+ * Execute a map query using either radius (near-sphere) or bounding-box mode.
+ * Returns map-friendly pin summaries only — no owner or media data.
+ */
+export async function queryMapReports(query: ReportsMapQueryDTO): Promise<MapReportPin[]> {
+  let mongoFilter: Record<string, unknown>;
+
+  if (isRadiusQuery(query)) {
+    mongoFilter = {
+      location: {
+        $nearSphere: {
+          $geometry: { type: 'Point', coordinates: [query.lng, query.lat] },
+          $maxDistance: query.radiusInMeters,
+        },
+      },
+    };
+  } else {
+    mongoFilter = {
+      location: {
+        $geoWithin: {
+          $box: [
+            [query.minLng, query.minLat],
+            [query.maxLng, query.maxLat],
+          ],
+        },
+      },
+    };
+  }
+
+  const docs = await ReportModel.find(mongoFilter)
+    .select(MAP_PROJECTION)
+    .limit(500)
+    .lean();
+
+  return docs.map((d) => ({
+    id: String(d._id),
+    title: d.title,
+    category: d.category,
+    status: d.status,
+    coordinates: d.location.coordinates as [number, number],
+  }));
+}

--- a/apps/api/src/modules/reports/reports.public.ts
+++ b/apps/api/src/modules/reports/reports.public.ts
@@ -1,0 +1,66 @@
+import { ReportModel } from './report.model';
+import { PublicReportListQueryDTO } from './reports.schemas';
+
+/** Fields safe to expose on the public listing endpoint. */
+const PUBLIC_PROJECTION = {
+  _id: 1,
+  title: 1,
+  category: 1,
+  status: 1,
+  location: 1,
+  createdAt: 1,
+  updatedAt: 1,
+} as const;
+
+export interface PublicReportItem {
+  id: string;
+  title: string;
+  category: string;
+  status: string;
+  location: { type: 'Point'; coordinates: [number, number] };
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PublicReportPage {
+  data: PublicReportItem[];
+  page: number;
+  pageSize: number;
+  total: number;
+}
+
+/**
+ * Fetch a paginated, field-restricted list of public reports.
+ * Strips owner identifiers, internal comments, and media metadata.
+ */
+export async function listPublicReports(
+  query: PublicReportListQueryDTO,
+): Promise<PublicReportPage> {
+  const { page, pageSize, status, category } = query;
+  const filter: Record<string, unknown> = {};
+
+  if (status) filter['status'] = status;
+  if (category) filter['category'] = category;
+
+  const [docs, total] = await Promise.all([
+    ReportModel.find(filter)
+      .select(PUBLIC_PROJECTION)
+      .sort({ createdAt: -1 })
+      .skip((page - 1) * pageSize)
+      .limit(pageSize)
+      .lean(),
+    ReportModel.countDocuments(filter),
+  ]);
+
+  const data: PublicReportItem[] = docs.map((d) => ({
+    id: String(d._id),
+    title: d.title,
+    category: d.category,
+    status: d.status,
+    location: d.location as PublicReportItem['location'],
+    createdAt: d.createdAt.toISOString(),
+    updatedAt: d.updatedAt.toISOString(),
+  }));
+
+  return { data, page, pageSize, total };
+}


### PR DESCRIPTION
Closes #153, closes #154, closes #155, closes #156

- **#153** — Added `otp.role-guard.ts`: blocks role escalation at OTP verification; only `CITIZEN` is self-assignable. Existing users always keep their stored role. District updates follow explicit first-login vs. repeat-login rules.
- **#154** — Added `refresh-token.audit.ts`: stamps issued/rotated/revoked timestamps and device metadata on token records; exposes a stale-token cleanup helper.
- **#155** — Added `reports.public.ts`: public listing returns a fixed safe projection (no owner IDs, comments, or media data) with status/category filters and stable pagination.
- **#156** — Added `reports.map.ts`: normalizes map queries to radius (`$nearSphere`) or bounding-box (`$geoWithin`) modes; returns typed pin summaries only, capped at 500 results.