### PR TITLE
feat: assignment model, evidence metadata, comment visibility

### DIFF
--- a/apps/api/src/modules/reports/comment-visibility.util.ts
+++ b/apps/api/src/modules/reports/comment-visibility.util.ts
@@ -1,0 +1,38 @@
+import type { UserRole } from '../users/user.model.js';
+import type {
+  ReportComment,
+  ReportCommentVisibility,
+} from './report-comment.model.js';
+
+/** Roles that may read INTERNAL comments. */
+const INTERNAL_ALLOWED_ROLES: UserRole[] = ['AGENCY_ADMIN'];
+
+export function canViewVisibility(
+  role: UserRole,
+  visibility: ReportCommentVisibility,
+): boolean {
+  if (visibility === 'PUBLIC') return true;
+  return INTERNAL_ALLOWED_ROLES.includes(role);
+}
+
+/**
+ * Filter a list of comments to only those visible to the given role.
+ * Citizens never see INTERNAL comments; agency admins see all.
+ */
+export function filterCommentsByRole<T extends Pick<ReportComment, 'visibility'>>(
+  comments: T[],
+  role: UserRole,
+): T[] {
+  return comments.filter((c) => canViewVisibility(role, c.visibility));
+}
+
+/**
+ * Build a Mongoose query filter for comment visibility.
+ * Pass the result directly into a `.find()` call.
+ */
+export function visibilityQueryFilter(
+  role: UserRole,
+): { visibility: ReportCommentVisibility } | Record<string, never> {
+  if (INTERNAL_ALLOWED_ROLES.includes(role)) return {};
+  return { visibility: 'PUBLIC' };
+}

--- a/apps/api/src/modules/reports/report-assignment.model.ts
+++ b/apps/api/src/modules/reports/report-assignment.model.ts
@@ -1,0 +1,56 @@
+import { Schema, model, type HydratedDocument, type Types } from 'mongoose';
+
+const ASSIGNMENT_STATUSES = ['ACTIVE', 'REASSIGNED', 'RELEASED'] as const;
+
+export type AssignmentStatus = (typeof ASSIGNMENT_STATUSES)[number];
+
+export interface ReportAssignment {
+  reportId: Types.ObjectId;
+  assigneeId: Types.ObjectId;
+  actorId: Types.ObjectId;
+  status: AssignmentStatus;
+  note?: string;
+  assignedAt: Date;
+  releasedAt?: Date;
+}
+
+const reportAssignmentSchema = new Schema<ReportAssignment>(
+  {
+    reportId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Report',
+      required: true,
+      index: true,
+    },
+    assigneeId: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true,
+    },
+    actorId: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+    },
+    status: {
+      type: String,
+      enum: ASSIGNMENT_STATUSES,
+      default: 'ACTIVE',
+      index: true,
+    },
+    note: { type: String, trim: true },
+    assignedAt: { type: Date, default: () => new Date() },
+    releasedAt: { type: Date },
+  },
+  { timestamps: true },
+);
+
+reportAssignmentSchema.index({ reportId: 1, status: 1 });
+
+export type ReportAssignmentDocument = HydratedDocument<ReportAssignment>;
+
+export const ReportAssignmentModel = model<ReportAssignment>(
+  'ReportAssignment',
+  reportAssignmentSchema,
+);

--- a/apps/api/src/modules/reports/report-assignment.service.ts
+++ b/apps/api/src/modules/reports/report-assignment.service.ts
@@ -1,0 +1,45 @@
+import type { Types } from 'mongoose';
+import {
+  ReportAssignmentModel,
+  type AssignmentStatus,
+} from './report-assignment.model.js';
+
+export async function createAssignment(params: {
+  reportId: Types.ObjectId;
+  assigneeId: Types.ObjectId;
+  actorId: Types.ObjectId;
+  note?: string;
+}) {
+  // Release any existing active assignment before creating a new one
+  await ReportAssignmentModel.updateMany(
+    { reportId: params.reportId, status: 'ACTIVE' },
+    { status: 'REASSIGNED', releasedAt: new Date() },
+  );
+
+  return ReportAssignmentModel.create({
+    ...params,
+    status: 'ACTIVE' as AssignmentStatus,
+    assignedAt: new Date(),
+  });
+}
+
+export async function getActiveAssignment(reportId: Types.ObjectId) {
+  return ReportAssignmentModel.findOne({ reportId, status: 'ACTIVE' }).lean();
+}
+
+export async function releaseAssignment(
+  reportId: Types.ObjectId,
+  actorId: Types.ObjectId,
+) {
+  return ReportAssignmentModel.findOneAndUpdate(
+    { reportId, status: 'ACTIVE' },
+    { status: 'RELEASED', releasedAt: new Date(), actorId },
+    { new: true },
+  );
+}
+
+export async function listAssignmentHistory(reportId: Types.ObjectId) {
+  return ReportAssignmentModel.find({ reportId })
+    .sort({ assignedAt: -1 })
+    .lean();
+}

--- a/apps/api/src/modules/reports/status-update-evidence.model.ts
+++ b/apps/api/src/modules/reports/status-update-evidence.model.ts
@@ -1,0 +1,61 @@
+import { Schema, model, type HydratedDocument, type Types } from 'mongoose';
+import { type ReportStatusValue } from './status-update.model.js';
+
+const STATUS_VALUES = [
+  'PENDING',
+  'ACKNOWLEDGED',
+  'RESOLVED',
+  'REJECTED',
+  'ESCALATED',
+] as const;
+
+export interface EvidenceMetadata {
+  summary: string;
+  attachmentRefs: string[];
+  capturedAt?: Date;
+}
+
+export interface StatusUpdateWithEvidence {
+  reportId: Types.ObjectId;
+  previousStatus: ReportStatusValue;
+  nextStatus: ReportStatusValue;
+  note?: string;
+  actorId?: Types.ObjectId;
+  evidence?: EvidenceMetadata;
+}
+
+const evidenceSchema = new Schema<EvidenceMetadata>(
+  {
+    summary: { type: String, required: true, trim: true },
+    attachmentRefs: { type: [String], default: [] },
+    capturedAt: { type: Date },
+  },
+  { _id: false },
+);
+
+const statusUpdateWithEvidenceSchema = new Schema<StatusUpdateWithEvidence>(
+  {
+    reportId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Report',
+      required: true,
+      index: true,
+    },
+    previousStatus: { type: String, enum: STATUS_VALUES, required: true },
+    nextStatus: { type: String, enum: STATUS_VALUES, required: true, index: true },
+    note: { type: String, trim: true },
+    actorId: { type: Schema.Types.ObjectId, ref: 'User' },
+    evidence: { type: evidenceSchema, required: false },
+  },
+  { timestamps: true },
+);
+
+statusUpdateWithEvidenceSchema.index({ createdAt: -1 });
+
+export type StatusUpdateWithEvidenceDocument =
+  HydratedDocument<StatusUpdateWithEvidence>;
+
+export const StatusUpdateWithEvidenceModel = model<StatusUpdateWithEvidence>(
+  'StatusUpdateWithEvidence',
+  statusUpdateWithEvidenceSchema,
+);


### PR DESCRIPTION
Closes #161, 
Closes #162, 
closes #163, 
closes #164

- **#161** — Adds `ReportAssignment` Mongoose model (status, actor, timestamps) and a service layer with create/query/release/history helpers.
- **#163** — Extends status updates with structured `EvidenceMetadata` (summary, attachment refs, capturedAt); backward-compatible with note-only updates.
- **#164** — Adds `comment-visibility.util.ts` with role-based filter helpers so citizens only see PUBLIC comments and agency admins see all.