### PR TITLE
Normalize report contracts, district derivation, and duplicate signals

### DIFF
--- a/apps/api/src/modules/reports/report-detail.dto.ts
+++ b/apps/api/src/modules/reports/report-detail.dto.ts
@@ -1,0 +1,71 @@
+/** Canonical authenticated report-detail response contract (issue #157). */
+
+export interface AnchorMeta {
+  status: 'ANCHOR_QUEUED' | 'ANCHOR_SUCCESS' | 'ANCHOR_FAILED';
+  txHash: string | null;
+  needsAttention: boolean;
+}
+
+export interface IntegrityData {
+  dataHash: string;
+  snapshotHash: string | null;
+  exifVerified: boolean;
+  exifDistanceMeters: number | null;
+  flag: 'NORMAL' | 'SUSPICIOUS';
+}
+
+export interface HistoryItem {
+  id: string;
+  status: string;
+  note: string;
+  visibility: 'public' | 'internal';
+  createdAt: string;
+}
+
+export interface MediaRef {
+  url: string;
+}
+
+export interface ReportDetailDTO {
+  id: string;
+  title: string;
+  description: string;
+  category: string;
+  status: string;
+  district: string | null;
+  location: { lng: number; lat: number };
+  anchor: AnchorMeta;
+  integrity: IntegrityData;
+  media: MediaRef[];
+  history: HistoryItem[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export function toReportDetailDTO(doc: Record<string, any>, history: HistoryItem[]): ReportDetailDTO {
+  return {
+    id: String(doc._id),
+    title: doc.title,
+    description: doc.description,
+    category: doc.category,
+    status: doc.status,
+    district: doc.district ?? null,
+    location: { lng: doc.location.coordinates[0], lat: doc.location.coordinates[1] },
+    anchor: {
+      status: doc.anchor_status,
+      txHash: doc.stellar_tx_hash,
+      needsAttention: doc.anchor_needs_attention,
+    },
+    integrity: {
+      dataHash: doc.data_hash,
+      snapshotHash: doc.snapshot_hash,
+      exifVerified: doc.exif_verified,
+      exifDistanceMeters: doc.exif_distance_meters,
+      flag: doc.integrity_flag,
+    },
+    media: (doc.media_urls as string[]).map((url) => ({ url })),
+    history,
+    createdAt: doc.createdAt instanceof Date ? doc.createdAt.toISOString() : String(doc.createdAt),
+    updatedAt: doc.updatedAt instanceof Date ? doc.updatedAt.toISOString() : String(doc.updatedAt),
+  };
+}

--- a/apps/api/src/modules/reports/report-district.service.ts
+++ b/apps/api/src/modules/reports/report-district.service.ts
@@ -1,0 +1,44 @@
+/** Derive and persist district on report creation from authenticated user context (issue #159). */
+
+export interface UserDistrictContext {
+  district?: string | null;
+}
+
+export type DistrictResolution =
+  | { resolved: true; district: string }
+  | { resolved: false; reason: 'missing_from_user' };
+
+/**
+ * Derive district from the authenticated user's profile.
+ * Does NOT infer from coordinates — geocoding is a deliberate future addition.
+ */
+export function deriveDistrict(user: UserDistrictContext): DistrictResolution {
+  if (user.district) {
+    return { resolved: true, district: user.district };
+  }
+  return { resolved: false, reason: 'missing_from_user' };
+}
+
+/**
+ * Resolve district for a new report payload.
+ * Returns the district string when available, null otherwise.
+ * Callers should log or surface the reason when unresolved.
+ */
+export function resolveReportDistrict(
+  user: UserDistrictContext,
+  onUnresolved?: (reason: string) => void,
+): string | null {
+  const result = deriveDistrict(user);
+  if (result.resolved) return result.district;
+  onUnresolved?.(result.reason);
+  return null;
+}
+
+/** Apply district to a mutable report creation payload in-place. */
+export function applyDistrictToPayload(
+  payload: Record<string, unknown>,
+  user: UserDistrictContext,
+  onUnresolved?: (reason: string) => void,
+): void {
+  payload['district'] = resolveReportDistrict(user, onUnresolved);
+}

--- a/apps/api/src/modules/reports/report-duplicate.service.ts
+++ b/apps/api/src/modules/reports/report-duplicate.service.ts
@@ -1,0 +1,53 @@
+/** Lightweight duplicate-report detection signals (issue #160). Non-blocking advisory only. */
+
+import { ReportModel } from './report.model';
+
+const PROXIMITY_METERS = 200;
+const TIME_WINDOW_MS = 24 * 60 * 60 * 1000; // 24 h
+
+export interface DuplicateCandidate {
+  reportId: string;
+  score: number; // 0–1, higher = more likely duplicate
+}
+
+export interface DuplicateSignals {
+  candidates: DuplicateCandidate[];
+  hasPotentialDuplicates: boolean;
+}
+
+/**
+ * Compute non-blocking duplicate hints for a new report.
+ * Checks proximity, recency, and category overlap.
+ * Never throws — returns empty signals on error so creation is never blocked.
+ */
+export async function computeDuplicateSignals(params: {
+  lng: number;
+  lat: number;
+  category: string;
+  createdAt?: Date;
+}): Promise<DuplicateSignals> {
+  try {
+    const since = new Date(Date.now() - TIME_WINDOW_MS);
+    const nearby = await ReportModel.find({
+      location: {
+        $nearSphere: {
+          $geometry: { type: 'Point', coordinates: [params.lng, params.lat] },
+          $maxDistance: PROXIMITY_METERS,
+        },
+      },
+      createdAt: { $gte: since },
+    })
+      .select({ _id: 1, category: 1 })
+      .limit(10)
+      .lean();
+
+    const candidates: DuplicateCandidate[] = nearby.map((doc) => {
+      const categoryMatch = doc.category === params.category ? 0.5 : 0;
+      return { reportId: String(doc._id), score: 0.5 + categoryMatch };
+    });
+
+    return { candidates, hasPotentialDuplicates: candidates.length > 0 };
+  } catch {
+    return { candidates: [], hasPotentialDuplicates: false };
+  }
+}

--- a/apps/api/src/modules/reports/report-list.dto.ts
+++ b/apps/api/src/modules/reports/report-list.dto.ts
@@ -1,0 +1,54 @@
+/** Normalized report-list response contract with stable pagination metadata (issue #158). */
+
+export interface ReportListItemDTO {
+  id: string;
+  title: string;
+  category: string;
+  status: string;
+  district: string | null;
+  location: { lng: number; lat: number };
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PaginationMeta {
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+}
+
+export interface ReportListResponseDTO {
+  data: ReportListItemDTO[];
+  pagination: PaginationMeta;
+}
+
+export function toReportListItemDTO(doc: Record<string, any>): ReportListItemDTO {
+  return {
+    id: String(doc._id),
+    title: doc.title,
+    category: doc.category,
+    status: doc.status,
+    district: doc.district ?? null,
+    location: { lng: doc.location.coordinates[0], lat: doc.location.coordinates[1] },
+    createdAt: doc.createdAt instanceof Date ? doc.createdAt.toISOString() : String(doc.createdAt),
+    updatedAt: doc.updatedAt instanceof Date ? doc.updatedAt.toISOString() : String(doc.updatedAt),
+  };
+}
+
+export function buildReportListResponse(
+  docs: Record<string, any>[],
+  total: number,
+  page: number,
+  pageSize: number,
+): ReportListResponseDTO {
+  return {
+    data: docs.map(toReportListItemDTO),
+    pagination: {
+      page,
+      pageSize,
+      total,
+      totalPages: Math.ceil(total / pageSize),
+    },
+  };
+}


### PR DESCRIPTION
Closes #157, closes #158, closes #159, closes #160

- **#157** — `report-detail.dto.ts`: typed `ReportDetailDTO` with anchor metadata, integrity data, media refs, and ordered history with public/internal visibility
- **#158** — `report-list.dto.ts`: `ReportListItemDTO` keeps list payload separate from detail; `buildReportListResponse` returns stable nested `pagination` object with `page`, `pageSize`, `total`, `totalPages`
- **#159** — `report-district.service.ts`: `resolveReportDistrict` pulls district from authenticated user context; explicit null fallback when missing; no coordinate inference
- **#160** — `report-duplicate.service.ts`: `computeDuplicateSignals` checks proximity (200 m), recency (24 h), and category overlap; returns advisory candidates; never blocks report creation