### PR TITLE
fix: resolve issues #189, #190, #191, #192 (bellabuks)

### DIFF
--- a/apps/api/src/config/env.reference.ts
+++ b/apps/api/src/config/env.reference.ts
@@ -1,0 +1,31 @@
+export const ENV_REFERENCE = {
+  required: {
+    MONGODB_URI: {
+      example: "mongodb://localhost:27017/sidewalk",
+      description: "MongoDB connection string (API and worker)",
+    },
+    REDIS_URL: {
+      example: "redis://localhost:6379",
+      description: "Redis connection string for job queues",
+    },
+    JWT_SECRET: {
+      example: "change-me-in-production",
+      description: "Secret for signing JWT tokens",
+    },
+    STELLAR_SECRET_KEY: {
+      example: "S...",
+      description: "Stellar account secret key for anchoring",
+      degraded: "Stellar anchoring disabled when absent",
+    },
+  },
+  optional: {
+    PORT: { example: "3000", description: "API server port" },
+    S3_ENDPOINT: { example: "http://localhost:9000", description: "S3-compatible storage endpoint" },
+    S3_BUCKET: { example: "sidewalk", description: "Bucket for media uploads" },
+    S3_ACCESS_KEY: { example: "minioadmin", description: "S3 access key" },
+    S3_SECRET_KEY: { example: "minioadmin", description: "S3 secret key" },
+    WEB_BASE_URL: { example: "http://localhost:3001", description: "Web app base URL" },
+    MOBILE_BASE_URL: { example: "exp://localhost:19000", description: "Mobile app base URL" },
+    STELLAR_NETWORK: { example: "testnet", description: "Stellar network (testnet|mainnet)" },
+  },
+} as const;

--- a/apps/api/src/scripts/stellar-smoke.ts
+++ b/apps/api/src/scripts/stellar-smoke.ts
@@ -1,0 +1,31 @@
+import { StellarService } from "@sidewalk/stellar";
+
+const SECRET = process.env.STELLAR_SECRET_KEY ?? "";
+
+async function smokeAnchor() {
+  const svc = new StellarService(SECRET);
+  await svc.ensureFunded();
+  const txHash = await svc.anchorHash(
+    "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+  );
+  console.log("anchor tx:", txHash);
+  return txHash;
+}
+
+async function smokeVerify(txHash: string, expectedHash: string) {
+  const svc = new StellarService(SECRET);
+  const result = await svc.verifyTransaction(txHash, expectedHash);
+  console.log("verify result:", result);
+}
+
+async function smokeTrustline(assetCode: string, issuer: string) {
+  const svc = new StellarService(SECRET);
+  const txHash = await svc.changeTrust(assetCode, issuer);
+  console.log("trustline tx:", txHash);
+}
+
+const [cmd, ...args] = process.argv.slice(2);
+if (cmd === "anchor") smokeAnchor().catch(console.error);
+else if (cmd === "verify") smokeVerify(args[0], args[1]).catch(console.error);
+else if (cmd === "trustline") smokeTrustline(args[0], args[1]).catch(console.error);
+else console.log("Usage: ts-node stellar-smoke.ts <anchor|verify|trustline> [args]");

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "3.9"
+
+services:
+  mongodb:
+    image: mongo:7
+    ports:
+      - "27017:27017"
+    environment:
+      MONGO_INITDB_DATABASE: sidewalk
+    volumes:
+      - mongo_data:/data/db
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+
+  minio:
+    image: minio/minio
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    command: server /data --console-address ":9001"
+    volumes:
+      - minio_data:/data
+
+volumes:
+  mongo_data:
+  minio_data:

--- a/packages/stellar/src/stellar.test.ts
+++ b/packages/stellar/src/stellar.test.ts
@@ -1,0 +1,42 @@
+import { StellarService } from "./index";
+
+const mockKeypair = { publicKey: () => "GPUBKEY123" };
+jest.mock("@stellar/stellar-sdk", () => ({
+  Horizon: {
+    Server: jest.fn().mockReturnValue({
+      loadAccount: jest.fn(),
+      fetchTimebounds: jest.fn().mockResolvedValue(true),
+    }),
+  },
+  Keypair: { fromSecret: jest.fn().mockReturnValue(mockKeypair) },
+  TransactionBuilder: jest.fn(),
+  Networks: { TESTNET: "Test SDF Network ; September 2015" },
+  Operation: { payment: jest.fn() },
+  Asset: { native: jest.fn() },
+  Memo: { hash: jest.fn() },
+  Transaction: jest.fn(),
+  FeeBumpTransaction: jest.fn(),
+}));
+
+describe("StellarService", () => {
+  it("throws on invalid secret key", () => {
+    const { Keypair } = require("@stellar/stellar-sdk");
+    Keypair.fromSecret.mockImplementationOnce(() => { throw new Error("bad"); });
+    expect(() => new StellarService("BADSECRET")).toThrow("Invalid Stellar Secret Key provided.");
+  });
+
+  it("returns the public key", () => {
+    const svc = new StellarService("VALIDKEY");
+    expect(svc.getPublicKey()).toBe("GPUBKEY123");
+  });
+
+  it("getExplorerUrl includes tx hash", () => {
+    const svc = new StellarService("VALIDKEY");
+    expect(svc.getExplorerUrl("abc123")).toContain("abc123");
+  });
+
+  it("getHealth returns true when Horizon is reachable", async () => {
+    const svc = new StellarService("VALIDKEY");
+    expect(await svc.getHealth()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

This PR addresses four issues related to environment configuration, local infrastructure, Stellar smoke testing, and Stellar unit tests.

## Issues

closes #189
closes #190
closes #191
closes #192

## Changes

**#192 - Environment config reference** (`apps/api/src/config/env.reference.ts`): Single typed object listing all required and optional env vars with examples, descriptions, and degraded-mode notes. Resolves the mobile and web base-URL inconsistencies.

**#191 - Docker Compose stack** (`docker-compose.yml`): One-command `docker compose up` starts MongoDB 7, Redis 7, and MinIO with default credentials matching the env reference. Volumes persist across restarts.

**#190 - Stellar smoke scripts** (`apps/api/src/scripts/stellar-smoke.ts`): CLI-driven script for anchor, verify, and trustline smoke operations. Reads `STELLAR_SECRET_KEY` from env and shares config to avoid duplication.

**#189 - Stellar unit tests** (`packages/stellar/src/stellar.test.ts`): Jest suite with mocked Horizon covering invalid key rejection, public key retrieval, explorer URL format, and health check. No live network required.