### PR TITLE
fix: resolve issues #185, #186, #187, #188 (Leothosine)

### DIFF
--- a/packages/stellar/src/anchor-idempotent.ts
+++ b/packages/stellar/src/anchor-idempotent.ts
@@ -1,0 +1,29 @@
+export type AnchorStatus = "success" | "failed";
+
+export type AnchorReceiptRecord = {
+  txHash: string;
+  network: string;
+  submittedAt: string;
+  attempts: number;
+  status: AnchorStatus;
+  errorMessage?: string;
+};
+
+const store = new Map<string, AnchorReceiptRecord>();
+
+export function recordAnchorReceipt(dataHash: string, record: AnchorReceiptRecord): void {
+  if (store.has(dataHash) && store.get(dataHash)!.status === "success") return;
+  store.set(dataHash, record);
+}
+
+export function getAnchorReceipt(dataHash: string): AnchorReceiptRecord | undefined {
+  return store.get(dataHash);
+}
+
+export function isAlreadyAnchored(dataHash: string): boolean {
+  return store.get(dataHash)?.status === "success";
+}
+
+export function clearReceipts(): void {
+  store.clear();
+}

--- a/packages/stellar/src/errors.ts
+++ b/packages/stellar/src/errors.ts
@@ -1,0 +1,39 @@
+export type AnchorErrorKind =
+  | "transient_network"
+  | "account_config"
+  | "invalid_hash"
+  | "submission_rejected"
+  | "unknown";
+
+export class AnchorError extends Error {
+  constructor(
+    public readonly kind: AnchorErrorKind,
+    message: string,
+    public readonly retryable: boolean,
+  ) {
+    super(message);
+    this.name = "AnchorError";
+  }
+}
+
+export function classifyAnchorError(error: unknown): AnchorError {
+  const e = error as {
+    response?: { status?: number; data?: { extras?: { result_codes?: { transaction?: string } } } };
+  };
+  const status = e?.response?.status;
+  const code = e?.response?.data?.extras?.result_codes?.transaction;
+
+  if (!status || status >= 500) {
+    return new AnchorError("transient_network", "Horizon unreachable or server error", true);
+  }
+  if (code === "tx_bad_auth") {
+    return new AnchorError("account_config", "Bad authentication on transaction", false);
+  }
+  if (code === "tx_bad_seq") {
+    return new AnchorError("invalid_hash", "Bad sequence number", true);
+  }
+  if (status === 400) {
+    return new AnchorError("submission_rejected", "Transaction rejected by Horizon", false);
+  }
+  return new AnchorError("unknown", "Unclassified anchor error", false);
+}

--- a/packages/stellar/src/explorer.ts
+++ b/packages/stellar/src/explorer.ts
@@ -1,0 +1,18 @@
+type StellarNetwork = "testnet" | "mainnet";
+
+const EXPLORER_BASES: Record<StellarNetwork, string> = {
+  testnet: "https://stellar.expert/explorer/testnet",
+  mainnet: "https://stellar.expert/explorer/public",
+};
+
+export function getExplorerBase(network: StellarNetwork = "testnet"): string {
+  return EXPLORER_BASES[network];
+}
+
+export function txUrl(txHash: string, network: StellarNetwork = "testnet"): string {
+  return `${getExplorerBase(network)}/tx/${txHash}`;
+}
+
+export function accountUrl(publicKey: string, network: StellarNetwork = "testnet"): string {
+  return `${getExplorerBase(network)}/account/${publicKey}`;
+}

--- a/packages/stellar/src/sponsorship.ts
+++ b/packages/stellar/src/sponsorship.ts
@@ -1,0 +1,39 @@
+import { TransactionBuilder, Networks, FeeBumpTransaction, Transaction } from "@stellar/stellar-sdk";
+
+export type SponsorshipErrorKind = "invalid_xdr" | "already_fee_bump" | "submission_failed";
+
+export class SponsorshipError extends Error {
+  constructor(public readonly kind: SponsorshipErrorKind, message: string) {
+    super(message);
+    this.name = "SponsorshipError";
+  }
+}
+
+export function parseInnerTransaction(xdr: string, network: string = Networks.TESTNET): Transaction {
+  let tx: Transaction | FeeBumpTransaction;
+  try {
+    tx = TransactionBuilder.fromXDR(xdr, network);
+  } catch {
+    throw new SponsorshipError("invalid_xdr", "Invalid XDR: cannot parse transaction");
+  }
+  if (tx instanceof FeeBumpTransaction) {
+    throw new SponsorshipError("already_fee_bump", "Transaction is already a fee bump");
+  }
+  return tx as Transaction;
+}
+
+export function wrapWithFeeBump(
+  innerTx: Transaction,
+  sponsorKeypair: { publicKey: () => string; sign: (tx: FeeBumpTransaction) => void },
+  fee = "10000",
+  network: string = Networks.TESTNET,
+): FeeBumpTransaction {
+  const fb = TransactionBuilder.buildFeeBumpTransaction(
+    sponsorKeypair as never,
+    fee,
+    innerTx,
+    network,
+  );
+  sponsorKeypair.sign(fb);
+  return fb;
+}


### PR DESCRIPTION
## Summary

This PR addresses four issues related to Stellar package hardening, error classification, explorer URL generation, and idempotent anchor writes.

## Issues

closes #185
closes #186
closes #187
closes #188

## Changes

**#188 - Typed anchor error classification** (`packages/stellar/src/errors.ts`): `AnchorError` class with `kind` and `retryable` fields. `classifyAnchorError` maps Horizon status codes and result codes to typed categories so workers can distinguish retryable from terminal failures.

**#187 - Explorer URL helper** (`packages/stellar/src/explorer.ts`): Centralized `txUrl` and `accountUrl` helpers keyed by network. Testnet/mainnet switching no longer requires string rewrites at call sites.

**#186 - Idempotent anchor receipt store** (`packages/stellar/src/anchor-idempotent.ts`): In-memory receipt registry that prevents duplicate success writes. `isAlreadyAnchored` guards re-entry; `recordAnchorReceipt` is a no-op when a success record already exists.

**#185 - Hardened fee sponsorship** (`packages/stellar/src/sponsorship.ts`): `parseInnerTransaction` validates XDR and rejects already-sponsored inputs with typed `SponsorshipError`. `wrapWithFeeBump` handles wrapping cleanly with explicit fee control.