### PR TITLE
fix: resolve issues #181, #182, #183, #184 (devwums)

### DIFF
--- a/packages/stellar/src/receipt.ts
+++ b/packages/stellar/src/receipt.ts
@@ -1,0 +1,27 @@
+export type AnchorReceipt = {
+  txHash: string;
+  network: "testnet" | "mainnet";
+  explorerUrl: string;
+  submittedAt: string;
+  memoHash: string;
+};
+
+const EXPLORER: Record<"testnet" | "mainnet", string> = {
+  testnet: "https://stellar.expert/explorer/testnet",
+  mainnet: "https://stellar.expert/explorer/public",
+};
+
+export function buildAnchorReceipt(
+  txHash: string,
+  memoHash: string,
+  network: "testnet" | "mainnet" = "testnet",
+  submittedAt = new Date().toISOString(),
+): AnchorReceipt {
+  return {
+    txHash,
+    network,
+    explorerUrl: `${EXPLORER[network]}/tx/${txHash}`,
+    submittedAt,
+    memoHash,
+  };
+}

--- a/packages/stellar/src/stellar-config.ts
+++ b/packages/stellar/src/stellar-config.ts
@@ -1,0 +1,33 @@
+export type StellarConfig = {
+  networkPassphrase: string;
+  horizonUrl: string;
+  explorerBaseUrl: string;
+  baseFee: string;
+  timeoutSeconds: number;
+};
+
+const TESTNET_DEFAULTS: StellarConfig = {
+  networkPassphrase: "Test SDF Network ; September 2015",
+  horizonUrl: "https://horizon-testnet.stellar.org",
+  explorerBaseUrl: "https://stellar.expert/explorer/testnet",
+  baseFee: "100",
+  timeoutSeconds: 30,
+};
+
+export function loadStellarConfig(env: NodeJS.ProcessEnv = process.env): StellarConfig {
+  return {
+    networkPassphrase: env.STELLAR_NETWORK_PASSPHRASE ?? TESTNET_DEFAULTS.networkPassphrase,
+    horizonUrl: env.STELLAR_HORIZON_URL ?? TESTNET_DEFAULTS.horizonUrl,
+    explorerBaseUrl: env.STELLAR_EXPLORER_BASE_URL ?? TESTNET_DEFAULTS.explorerBaseUrl,
+    baseFee: env.STELLAR_BASE_FEE ?? TESTNET_DEFAULTS.baseFee,
+    timeoutSeconds: Number(env.STELLAR_TIMEOUT_SECONDS ?? TESTNET_DEFAULTS.timeoutSeconds),
+  };
+}
+
+export function validateStellarConfig(config: StellarConfig): void {
+  if (!config.horizonUrl) throw new Error("STELLAR_HORIZON_URL is required");
+  if (!config.networkPassphrase) throw new Error("STELLAR_NETWORK_PASSPHRASE is required");
+  if (isNaN(config.timeoutSeconds) || config.timeoutSeconds <= 0) {
+    throw new Error("STELLAR_TIMEOUT_SECONDS must be a positive number");
+  }
+}

--- a/packages/stellar/src/transport.ts
+++ b/packages/stellar/src/transport.ts
@@ -1,0 +1,35 @@
+import { Horizon, Keypair, Networks } from "@stellar/stellar-sdk";
+
+export type NetworkConfig = {
+  horizonUrl: string;
+  networkPassphrase: string;
+};
+
+const TESTNET_CONFIG: NetworkConfig = {
+  horizonUrl: "https://horizon-testnet.stellar.org",
+  networkPassphrase: Networks.TESTNET,
+};
+
+export class StellarTransport {
+  readonly server: Horizon.Server;
+  readonly keypair: Keypair;
+  readonly networkPassphrase: string;
+
+  constructor(secretKey: string, config: NetworkConfig = TESTNET_CONFIG) {
+    try {
+      this.keypair = Keypair.fromSecret(secretKey);
+    } catch {
+      throw new Error("Invalid Stellar secret key");
+    }
+    this.server = new Horizon.Server(config.horizonUrl);
+    this.networkPassphrase = config.networkPassphrase;
+  }
+
+  get publicKey(): string {
+    return this.keypair.publicKey();
+  }
+
+  async loadAccount() {
+    return this.server.loadAccount(this.publicKey);
+  }
+}

--- a/packages/stellar/src/verification-result.ts
+++ b/packages/stellar/src/verification-result.ts
@@ -1,0 +1,30 @@
+export type VerificationStatus = "valid" | "invalid" | "not_found" | "hash_mismatch";
+
+export type VerificationResult = {
+  status: VerificationStatus;
+  txHash: string;
+  onChainHash?: string;
+  timestamp?: string;
+  sourceAccount?: string;
+  network: string;
+  reason?: string;
+};
+
+export function buildVerificationResult(params: {
+  txHash: string;
+  expectedHash: string;
+  onChainHash?: string;
+  timestamp?: string;
+  sourceAccount?: string;
+  network?: string;
+}): VerificationResult {
+  const { txHash, expectedHash, onChainHash, timestamp, sourceAccount, network = "testnet" } = params;
+
+  if (!onChainHash) {
+    return { status: "not_found", txHash, network, reason: "Transaction not found on chain" };
+  }
+  if (onChainHash !== expectedHash) {
+    return { status: "hash_mismatch", txHash, onChainHash, timestamp, sourceAccount, network, reason: "On-chain hash does not match expected value" };
+  }
+  return { status: "valid", txHash, onChainHash, timestamp, sourceAccount, network };
+}


### PR DESCRIPTION
## Summary

This PR addresses four issues focused on refactoring the `@sidewalk/stellar` package into cleaner layers, externalizing configuration, and strengthening the anchor and verification contracts.

## Issues

closes #181
closes #182
closes #183
closes #184

## Changes

**#181 - Transport layer** (`packages/stellar/src/transport.ts`): `StellarTransport` class isolates Horizon client setup and keypair management from proof logic. Accepts a `NetworkConfig` so callers are not locked to testnet.

**#182 - Externalized config** (`packages/stellar/src/stellar-config.ts`): `loadStellarConfig` reads all Stellar settings from env with safe testnet defaults. `validateStellarConfig` fails loudly on missing or malformed values at startup.

**#183 - Typed anchor receipt** (`packages/stellar/src/receipt.ts`): `AnchorReceipt` type includes tx hash, network, explorer URL, submitted-at timestamp, and memo hash. `buildAnchorReceipt` constructs it cleanly without manual URL assembly at call sites.

**#184 - Normalized verification result** (`packages/stellar/src/verification-result.ts`): `VerificationResult` with `status` discriminant (`valid`, `hash_mismatch`, `not_found`). Consumers can branch on structured results instead of catching generic errors.