### PR TITLE
fix: resolve issues #165, #166, #167, #168 (yusuftomilola)

### DIFF
--- a/apps/api/src/modules/media/draft-lifecycle.service.ts
+++ b/apps/api/src/modules/media/draft-lifecycle.service.ts
@@ -1,0 +1,33 @@
+export type DraftStatus = "open" | "finalized" | "expired";
+
+export type MediaDraft = {
+  id: string;
+  ownerId: string;
+  status: DraftStatus;
+  expiresAt: Date;
+};
+
+export function isDraftUsable(draft: MediaDraft, requesterId: string): boolean {
+  if (draft.ownerId !== requesterId) return false;
+  if (draft.status !== "open") return false;
+  if (new Date() > draft.expiresAt) return false;
+  return true;
+}
+
+export function finalizeDraft(draft: MediaDraft): MediaDraft {
+  return { ...draft, status: "finalized" };
+}
+
+export function expireDraft(draft: MediaDraft): MediaDraft {
+  return { ...draft, status: "expired" };
+}
+
+export function assertDraftUsable(draft: MediaDraft, requesterId: string): void {
+  if (!isDraftUsable(draft, requesterId)) {
+    const reason =
+      draft.ownerId !== requesterId ? "Not the draft owner" :
+      draft.status !== "open" ? `Draft is ${draft.status}` :
+      "Draft has expired";
+    throw Object.assign(new Error(reason), { code: "DRAFT_UNUSABLE" });
+  }
+}

--- a/apps/api/src/modules/media/media-intake.service.ts
+++ b/apps/api/src/modules/media/media-intake.service.ts
@@ -1,0 +1,23 @@
+export type IntakeValidationResult = { valid: boolean; reason?: string };
+export type MediaIntakeJob = { mediaId: string; filePath: string; mimeType: string };
+
+const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp", "video/mp4"];
+const MAX_BYTES = 50 * 1024 * 1024;
+
+export function validateIntake(file: { size: number; mimeType: string }): IntakeValidationResult {
+  if (!ALLOWED_TYPES.includes(file.mimeType)) {
+    return { valid: false, reason: `Unsupported media type: ${file.mimeType}` };
+  }
+  if (file.size > MAX_BYTES) {
+    return { valid: false, reason: "File exceeds 50 MB limit" };
+  }
+  return { valid: true };
+}
+
+export function buildIntakeJob(
+  mediaId: string,
+  filePath: string,
+  mimeType: string,
+): MediaIntakeJob {
+  return { mediaId, filePath, mimeType };
+}

--- a/apps/api/src/modules/media/media-reference.ts
+++ b/apps/api/src/modules/media/media-reference.ts
@@ -1,0 +1,24 @@
+export type ProcessingStatus = "pending" | "ready" | "failed";
+
+export type MediaReference = {
+  id: string;
+  mimeType: string;
+  processingStatus: ProcessingStatus;
+  securePreviewCapable: boolean;
+  url?: string;
+};
+
+export function toMediaReference(media: {
+  _id: string;
+  mimeType: string;
+  status: string;
+  storedUrl?: string;
+}): MediaReference {
+  return {
+    id: media._id,
+    mimeType: media.mimeType,
+    processingStatus: (media.status as ProcessingStatus) ?? "pending",
+    securePreviewCapable: media.status === "ready",
+    url: media.storedUrl,
+  };
+}

--- a/apps/api/src/modules/reports/timeline.ts
+++ b/apps/api/src/modules/reports/timeline.ts
@@ -1,0 +1,22 @@
+export type TimelineEventType =
+  | "report_created"
+  | "status_updated"
+  | "comment_added"
+  | "anchor_completed"
+  | "anchor_failed";
+
+export type TimelineEvent = {
+  type: TimelineEventType;
+  occurredAt: string;
+  payload: Record<string, unknown>;
+  internal: boolean;
+};
+
+export function buildTimeline(
+  events: TimelineEvent[],
+  includeInternal = false,
+): TimelineEvent[] {
+  return events
+    .filter((e) => includeInternal || !e.internal)
+    .sort((a, b) => new Date(a.occurredAt).getTime() - new Date(b.occurredAt).getTime());
+}


### PR DESCRIPTION
## Summary

This PR addresses four issues related to report lifecycle timeline, media draft lifecycle hardening, media intake abstraction, and typed media reference objects.

## Issues

closes #165
closes #166
closes #167
closes #168

## Changes

**#168 - Media reference objects** (`apps/api/src/modules/media/media-reference.ts`): `MediaReference` type includes media ID, MIME type, processing status, and secure-preview capability hint. `toMediaReference` maps internal media documents to the stable reference shape without exposing storage keys.

**#167 - Media intake abstraction** (`apps/api/src/modules/media/media-intake.service.ts`): Separates intake validation (type and size checks) from storage write and queue orchestration. `validateIntake` returns a typed result; `buildIntakeJob` produces a queue-ready payload.

**#166 - Draft lifecycle hardening** (`apps/api/src/modules/media/draft-lifecycle.service.ts`): `isDraftUsable` enforces owner check, open status, and expiry. `assertDraftUsable` throws with a structured `DRAFT_UNUSABLE` code so controllers stay thin. `finalizeDraft` and `expireDraft` return new objects to avoid mutation.

**#165 - Report timeline** (`apps/api/src/modules/reports/timeline.ts`): `TimelineEvent` type covers all lifecycle event kinds. `buildTimeline` filters internal events by caller role and sorts by `occurredAt` for deterministic output.