### PR TITLE
fix: resolve issues #169, #170, #171, #172 (mftee)

### DIFF
--- a/apps/api/src/modules/media/media-access.guard.ts
+++ b/apps/api/src/modules/media/media-access.guard.ts
@@ -1,0 +1,22 @@
+export type RequesterRole = "admin" | "agency" | "citizen";
+
+export type MediaAccessContext = {
+  requesterId: string;
+  requesterRole: RequesterRole;
+  reportOwnerId: string;
+  assignedAgencyId?: string;
+  requesterAgencyId?: string;
+};
+
+export function canAccessSecureMedia(ctx: MediaAccessContext): boolean {
+  if (ctx.requesterRole === "admin") return true;
+  if (ctx.requesterId === ctx.reportOwnerId) return true;
+  if (
+    ctx.requesterRole === "agency" &&
+    ctx.assignedAgencyId &&
+    ctx.requesterAgencyId === ctx.assignedAgencyId
+  ) {
+    return true;
+  }
+  return false;
+}

--- a/apps/api/src/modules/reports/agency-queue.service.ts
+++ b/apps/api/src/modules/reports/agency-queue.service.ts
@@ -1,0 +1,24 @@
+export type AgencyQueueFilter = {
+  districtId: string;
+  status?: string;
+  category?: string;
+  page?: number;
+  limit?: number;
+};
+
+export type AgencyQueueQuery = {
+  filter: Record<string, unknown>;
+  skip: number;
+  limit: number;
+};
+
+export function buildAgencyQueueQuery(filter: AgencyQueueFilter): AgencyQueueQuery {
+  const match: Record<string, unknown> = { districtId: filter.districtId };
+  if (filter.status) match.status = filter.status;
+  if (filter.category) match.category = filter.category;
+
+  const page = Math.max(1, filter.page ?? 1);
+  const limit = Math.min(filter.limit ?? 20, 100);
+
+  return { filter: match, skip: (page - 1) * limit, limit };
+}

--- a/apps/api/src/modules/reports/moderation-flags.ts
+++ b/apps/api/src/modules/reports/moderation-flags.ts
@@ -1,0 +1,20 @@
+export type ModerationFlagKind = "exif_mismatch" | "duplicate_suspected" | "integrity_low";
+
+export type ModerationFlag = {
+  kind: ModerationFlagKind;
+  detectedAt: string;
+  detail?: string;
+};
+
+export function buildModerationFlags(report: {
+  integrityFlag?: boolean;
+  exifMismatch?: boolean;
+  duplicateSuspected?: boolean;
+}): ModerationFlag[] {
+  const flags: ModerationFlag[] = [];
+  const now = new Date().toISOString();
+  if (report.exifMismatch) flags.push({ kind: "exif_mismatch", detectedAt: now });
+  if (report.duplicateSuspected) flags.push({ kind: "duplicate_suspected", detectedAt: now });
+  if (report.integrityFlag) flags.push({ kind: "integrity_low", detectedAt: now });
+  return flags;
+}

--- a/apps/api/src/modules/reports/proof.controller.ts
+++ b/apps/api/src/modules/reports/proof.controller.ts
@@ -1,0 +1,35 @@
+import { Request, Response } from "express";
+
+type ReportService = {
+  findById(id: string): Promise<{
+    snapshotHash?: string;
+    anchorStatus?: string;
+    anchorTxHash?: string;
+    anchorVerifiedAt?: string;
+  } | null>;
+};
+
+type AnchorService = {
+  getExplorerUrl(txHash: string): string;
+};
+
+export function makeProofController(reportSvc: ReportService, anchorSvc: AnchorService) {
+  return async function getReportProof(req: Request, res: Response): Promise<void> {
+    const { reportId } = req.params;
+    const report = await reportSvc.findById(reportId);
+
+    if (!report) {
+      res.status(404).json({ error: "Report not found" });
+      return;
+    }
+
+    res.json({
+      reportId,
+      snapshotHash: report.snapshotHash ?? null,
+      anchorStatus: report.anchorStatus ?? "unanchored",
+      txHash: report.anchorTxHash ?? null,
+      explorerUrl: report.anchorTxHash ? anchorSvc.getExplorerUrl(report.anchorTxHash) : null,
+      verifiedAt: report.anchorVerifiedAt ?? null,
+    });
+  };
+}


### PR DESCRIPTION
## Summary

This PR addresses four issues covering secure media authorization, district-scoped agency queues, moderation flags, and a public proof endpoint.

## Issues

closes #169
closes #170
closes #171
closes #172

## Changes

**#172 - Public proof endpoint** (`apps/api/src/modules/reports/proof.controller.ts`): Factory function `makeProofController` returns a handler that exposes report ID, snapshot hash, anchor status, tx hash, and explorer URL. Private report content is never included. Returns 404 for unknown reports.

**#171 - Moderation flags** (`apps/api/src/modules/reports/moderation-flags.ts`): `ModerationFlag` type with `kind`, `detectedAt`, and optional `detail`. `buildModerationFlags` derives a typed flag array from integrity and EXIF signals, keeping the summary `integrityFlag` field independent.

**#170 - District-scoped agency queue** (`apps/api/src/modules/reports/agency-queue.service.ts`): `buildAgencyQueueQuery` returns a Mongo-compatible filter scoped to `districtId` with optional status/category filters and bounded pagination. Separated from generic citizen list queries.

**#169 - Secure media access guard** (`apps/api/src/modules/media/media-access.guard.ts`): `canAccessSecureMedia` allows admins, report owners, and assigned agency users. Unrelated agency users are blocked. Logic is a pure function, easy to unit-test and log around.