### PR TITLE
fix: resolve issues #173, #174, #175, #176 (AbdulmujibOladayo)

### DIFF
--- a/apps/api/src/core/audit-log.ts
+++ b/apps/api/src/core/audit-log.ts
@@ -1,0 +1,32 @@
+export type AuditAction =
+  | "report_created"
+  | "report_status_updated"
+  | "media_uploaded"
+  | "auth_login"
+  | "auth_logout";
+
+export type AuditRecord = {
+  actor: string;
+  action: AuditAction;
+  targetType: string;
+  targetId: string;
+  timestamp: string;
+  metadata?: Record<string, unknown>;
+};
+
+export function buildAuditRecord(
+  actor: string,
+  action: AuditAction,
+  targetType: string,
+  targetId: string,
+  metadata?: Record<string, unknown>,
+): AuditRecord {
+  return {
+    actor,
+    action,
+    targetType,
+    targetId,
+    timestamp: new Date().toISOString(),
+    metadata,
+  };
+}

--- a/apps/api/src/modules/admin/taxonomy-config.ts
+++ b/apps/api/src/modules/admin/taxonomy-config.ts
@@ -1,0 +1,26 @@
+export type TaxonomyConfig = {
+  enabledCategories: string[];
+  integrityThreshold: number;
+  maxReportsPerUser: number;
+};
+
+const DEFAULT_CONFIG: TaxonomyConfig = {
+  enabledCategories: ["road_damage", "flooding", "illegal_dumping", "broken_lighting"],
+  integrityThreshold: 0.7,
+  maxReportsPerUser: 50,
+};
+
+let activeConfig: TaxonomyConfig = { ...DEFAULT_CONFIG };
+
+export function getConfig(): TaxonomyConfig {
+  return { ...activeConfig };
+}
+
+export function updateConfig(patch: Partial<TaxonomyConfig>): TaxonomyConfig {
+  activeConfig = { ...activeConfig, ...patch };
+  return getConfig();
+}
+
+export function resetConfig(): void {
+  activeConfig = { ...DEFAULT_CONFIG };
+}

--- a/apps/api/src/modules/reports/analytics.ts
+++ b/apps/api/src/modules/reports/analytics.ts
@@ -1,0 +1,25 @@
+export type ReportSummary = {
+  byStatus: Record<string, number>;
+  byCategory: Record<string, number>;
+  byDistrict: Record<string, number>;
+  total: number;
+};
+
+export function aggregateSummary(
+  reports: Array<{ status: string; category: string; districtId: string }>,
+  districtId?: string,
+): ReportSummary {
+  const scoped = districtId ? reports.filter((r) => r.districtId === districtId) : reports;
+
+  const byStatus: Record<string, number> = {};
+  const byCategory: Record<string, number> = {};
+  const byDistrict: Record<string, number> = {};
+
+  for (const r of scoped) {
+    byStatus[r.status] = (byStatus[r.status] ?? 0) + 1;
+    byCategory[r.category] = (byCategory[r.category] ?? 0) + 1;
+    byDistrict[r.districtId] = (byDistrict[r.districtId] ?? 0) + 1;
+  }
+
+  return { byStatus, byCategory, byDistrict, total: scoped.length };
+}

--- a/apps/api/src/modules/reports/search.service.ts
+++ b/apps/api/src/modules/reports/search.service.ts
@@ -1,0 +1,23 @@
+export type TextSearchFilter = {
+  query: string;
+  status?: string;
+  category?: string;
+};
+
+export type TextSearchQuery = {
+  filter: Record<string, unknown>;
+};
+
+export function buildTextSearchQuery(filter: TextSearchFilter): TextSearchQuery {
+  const match: Record<string, unknown> = {
+    $text: { $search: filter.query },
+  };
+  if (filter.status) match.status = filter.status;
+  if (filter.category) match.category = filter.category;
+  return { filter: match };
+}
+
+export const REPORT_TEXT_INDEX = {
+  fields: { title: "text", description: "text" },
+  options: { name: "report_text_search", default_language: "english" },
+};


### PR DESCRIPTION
## Summary

This PR addresses four issues covering text search for report discovery, summary analytics, admin taxonomy configuration, and audit logging.

## Issues

closes #173
closes #174
closes #175
closes #176

## Changes

**#176 - Audit logging** (`apps/api/src/core/audit-log.ts`): `AuditRecord` type captures actor, action, target type/ID, timestamp, and optional metadata. `buildAuditRecord` factory keeps sensitive data out of the record by design - callers decide what metadata to include.

**#175 - Admin taxonomy config** (`apps/api/src/modules/admin/taxonomy-config.ts`): In-memory config store with typed `TaxonomyConfig`. `getConfig` returns a copy; `updateConfig` applies a partial patch; `resetConfig` restores defaults. System works with defaults before any admin setup.

**#174 - Summary analytics** (`apps/api/src/modules/reports/analytics.ts`): `aggregateSummary` computes counts by status, category, and district from a report array. Accepts an optional `districtId` to scope results for agency users. No external infrastructure required.

**#173 - Text search** (`apps/api/src/modules/reports/search.service.ts`): `buildTextSearchQuery` constructs a Mongo `` filter composable with status and category filters. `REPORT_TEXT_INDEX` exports the index definition for migration scripts. No external search infrastructure needed for MVP.