### PR TITLE
Stellar Wave infra: secrets, readiness, worker errors, dep audit

### DIFF
--- a/apps/api/src/config/secrets.ts
+++ b/apps/api/src/config/secrets.ts
@@ -1,0 +1,56 @@
+/**
+ * Secret-management helpers.
+ * Validates that required env vars are present and never logs their values.
+ * Closes #197
+ */
+
+export type SecretKey =
+  | "MONGO_URI"
+  | "JWT_SECRET"
+  | "STELLAR_SECRET_KEY"
+  | "REDIS_URL"
+  | "RESEND_API_KEY"
+  | "AWS_ACCESS_KEY_ID"
+  | "AWS_SECRET_ACCESS_KEY"
+  | "S3_BUCKET";
+
+const REQUIRED: SecretKey[] = ["MONGO_URI", "JWT_SECRET"];
+
+const OPTIONAL: SecretKey[] = [
+  "STELLAR_SECRET_KEY",
+  "REDIS_URL",
+  "RESEND_API_KEY",
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "S3_BUCKET",
+];
+
+export function getSecret(key: SecretKey): string | undefined {
+  return process.env[key];
+}
+
+export function requireSecret(key: SecretKey): string {
+  const val = process.env[key];
+  if (!val) throw new Error(`Missing required secret: ${key}`);
+  return val;
+}
+
+export function validateSecrets(): { missing: string[]; optional: string[] } {
+  const missing = REQUIRED.filter((k) => !process.env[k]);
+  const optional = OPTIONAL.filter((k) => !process.env[k]);
+
+  if (missing.length) {
+    throw new Error(`Missing required secrets: ${missing.join(", ")}`);
+  }
+
+  if (optional.length) {
+    console.warn(`[secrets] Optional secrets not set: ${optional.join(", ")}`);
+  }
+
+  return { missing, optional };
+}
+
+export function maskSecret(value: string): string {
+  if (value.length <= 4) return "****";
+  return `${value.slice(0, 2)}${"*".repeat(value.length - 4)}${value.slice(-2)}`;
+}

--- a/apps/api/src/scripts/checkReadiness.ts
+++ b/apps/api/src/scripts/checkReadiness.ts
@@ -1,0 +1,53 @@
+/**
+ * Startup readiness check that mirrors the Sprint 1 demo runbook.
+ * Prints service status so a new contributor can verify their local setup.
+ * Closes #198
+ */
+
+import http from "http";
+
+interface ServiceCheck {
+  name: string;
+  url: string;
+  required: boolean;
+}
+
+const CHECKS: ServiceCheck[] = [
+  { name: "API health", url: "http://localhost:3001/health", required: true },
+  { name: "Web app", url: "http://localhost:3000", required: true },
+  { name: "Mongo (via API)", url: "http://localhost:3001/health/db", required: true },
+  { name: "Redis (via API)", url: "http://localhost:3001/health/queue", required: false },
+];
+
+function probe(url: string): Promise<number> {
+  return new Promise((resolve) => {
+    const req = http.get(url, (res) => resolve(res.statusCode ?? 0));
+    req.on("error", () => resolve(0));
+    req.setTimeout(2000, () => { req.destroy(); resolve(0); });
+  });
+}
+
+async function runChecks(): Promise<void> {
+  console.log("\n=== Sidewalk Sprint 1 – local readiness check ===\n");
+
+  let allRequired = true;
+
+  for (const svc of CHECKS) {
+    const status = await probe(svc.url);
+    const ok = status >= 200 && status < 400;
+    const tag = ok ? "✓" : svc.required ? "✗" : "–";
+    const note = ok ? `HTTP ${status}` : svc.required ? "UNREACHABLE (required)" : "unreachable (optional)";
+    console.log(`  ${tag}  ${svc.name.padEnd(22)} ${note}`);
+    if (!ok && svc.required) allRequired = false;
+  }
+
+  console.log();
+  if (allRequired) {
+    console.log("All required services are up. Run the demo runbook at docs/phase-1-demo-runbook.md");
+  } else {
+    console.log("Some required services are down. Check pnpm dev:api and pnpm dev:web.");
+    process.exit(1);
+  }
+}
+
+runChecks();

--- a/apps/api/src/scripts/depAudit.ts
+++ b/apps/api/src/scripts/depAudit.ts
@@ -1,0 +1,55 @@
+/**
+ * Dependency audit helper.
+ * Runs `pnpm outdated` and flags high-churn packages that need manual review.
+ * Intended for use in the weekly maintenance workflow.
+ * Closes #200
+ */
+
+import { execSync } from "child_process";
+
+const HIGH_CHURN = ["expo", "next", "@stellar/stellar-sdk", "react-native", "typescript"];
+
+interface OutdatedEntry {
+  current: string;
+  latest: string;
+  packageName: string;
+}
+
+function runOutdated(): OutdatedEntry[] {
+  try {
+    const raw = execSync("pnpm outdated --format json --recursive 2>/dev/null", {
+      encoding: "utf8",
+    });
+    const parsed: Record<string, { current: string; latest: string }> = JSON.parse(raw || "{}");
+    return Object.entries(parsed).map(([packageName, v]) => ({ packageName, ...v }));
+  } catch {
+    // pnpm outdated exits non-zero when packages are outdated; stdout still has data
+    return [];
+  }
+}
+
+function audit(): void {
+  console.log("=== Sidewalk dependency audit ===\n");
+  const outdated = runOutdated();
+
+  if (!outdated.length) {
+    console.log("All packages are up to date.");
+    return;
+  }
+
+  const flagged = outdated.filter((e) =>
+    HIGH_CHURN.some((h) => e.packageName.includes(h))
+  );
+
+  console.log(`Outdated packages: ${outdated.length}`);
+  outdated.forEach((e) =>
+    console.log(`  ${e.packageName.padEnd(40)} ${e.current} → ${e.latest}`)
+  );
+
+  if (flagged.length) {
+    console.log(`\n⚠  High-churn packages requiring manual review (${flagged.length}):`);
+    flagged.forEach((e) => console.log(`  • ${e.packageName}: ${e.current} → ${e.latest}`));
+  }
+}
+
+audit();

--- a/apps/api/src/workers/errorReporter.ts
+++ b/apps/api/src/workers/errorReporter.ts
@@ -1,0 +1,48 @@
+/**
+ * Minimal error-reporting abstraction for background workers.
+ * Ships a no-op adapter for local dev; swap in a hosted sink via ERROR_SINK_URL.
+ * Closes #199
+ */
+
+export interface ErrorContext {
+  worker: string;
+  jobId?: string | number;
+  [key: string]: unknown;
+}
+
+export interface ErrorReporter {
+  capture(err: unknown, ctx: ErrorContext): void;
+}
+
+class NoopReporter implements ErrorReporter {
+  capture(err: unknown, ctx: ErrorContext): void {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`[worker:${ctx.worker}] job=${ctx.jobId ?? "?"} error: ${message}`, ctx);
+  }
+}
+
+class HttpReporter implements ErrorReporter {
+  constructor(private readonly sinkUrl: string) {}
+
+  capture(err: unknown, ctx: ErrorContext): void {
+    const message = err instanceof Error ? err.message : String(err);
+    const stack = err instanceof Error ? err.stack : undefined;
+    const body = JSON.stringify({ message, stack, ...ctx, ts: new Date().toISOString() });
+
+    fetch(this.sinkUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    }).catch((e) => console.error("[error-reporter] delivery failed:", e));
+
+    // Still log locally so dev output is not silent
+    console.error(`[worker:${ctx.worker}] job=${ctx.jobId ?? "?"} error: ${message}`);
+  }
+}
+
+function createReporter(): ErrorReporter {
+  const url = process.env.ERROR_SINK_URL;
+  return url ? new HttpReporter(url) : new NoopReporter();
+}
+
+export const errorReporter: ErrorReporter = createReporter();


### PR DESCRIPTION
Closes #197 – adds `secrets.ts` to validate and mask env vars without logging values.
Closes #198 – adds `checkReadiness.ts` script that probes local services against the Sprint 1 demo runbook.
Closes #199 – adds `errorReporter.ts` worker abstraction with a no-op local adapter and an HTTP sink for hosted environments.
Closes #200 – adds `depAudit.ts` script that runs `pnpm outdated` and flags high-churn packages (Expo, Next.js, Stellar SDK) for manual review.