### PR TITLE
feat(mobile): upload retry, attachment carousel, a11y helpers, format utils

### DIFF
--- a/apps/mobile/src/components/AttachmentCarousel.tsx
+++ b/apps/mobile/src/components/AttachmentCarousel.tsx
@@ -1,0 +1,65 @@
+/** Attachment preview carousel for report detail (issue #212) */
+
+import React, { useState } from "react";
+import {
+  View,
+  Image,
+  FlatList,
+  TouchableOpacity,
+  Modal,
+  StyleSheet,
+  Text,
+  Dimensions,
+} from "react-native";
+
+interface Props {
+  urls: string[];
+}
+
+const { width } = Dimensions.get("window");
+
+export function AttachmentCarousel({ urls }: Props) {
+  const [fullscreen, setFullscreen] = useState<string | null>(null);
+
+  if (!urls.length) return null;
+
+  return (
+    <View>
+      <FlatList
+        horizontal
+        data={urls}
+        keyExtractor={(item, i) => `${item}-${i}`}
+        renderItem={({ item }) => (
+          <TouchableOpacity onPress={() => setFullscreen(item)}>
+            <Image
+              source={{ uri: item }}
+              style={styles.thumb}
+              onError={() => {/* fail silently */}}
+              accessibilityLabel="Report attachment"
+            />
+          </TouchableOpacity>
+        )}
+        showsHorizontalScrollIndicator={false}
+      />
+
+      <Modal visible={!!fullscreen} transparent animationType="fade">
+        <View style={styles.overlay}>
+          <TouchableOpacity style={styles.close} onPress={() => setFullscreen(null)}>
+            <Text style={styles.closeText}>✕</Text>
+          </TouchableOpacity>
+          {fullscreen && (
+            <Image source={{ uri: fullscreen }} style={styles.full} resizeMode="contain" />
+          )}
+        </View>
+      </Modal>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  thumb: { width: 100, height: 100, borderRadius: 8, marginRight: 8 },
+  overlay: { flex: 1, backgroundColor: "#000d", justifyContent: "center", alignItems: "center" },
+  full: { width, height: width },
+  close: { position: "absolute", top: 48, right: 20 },
+  closeText: { color: "#fff", fontSize: 24 },
+});

--- a/apps/mobile/src/hooks/useUploadRetry.ts
+++ b/apps/mobile/src/hooks/useUploadRetry.ts
@@ -1,0 +1,56 @@
+/** Background-friendly upload retry handling (issue #211) */
+
+import { useState, useCallback } from "react";
+
+type UploadStatus = "pending" | "uploading" | "done" | "failed";
+
+interface UploadEntry {
+  id: string;
+  uri: string;
+  status: UploadStatus;
+  error?: string;
+}
+
+type UploadFn = (uri: string) => Promise<void>;
+
+export function useUploadRetry(uploadFn: UploadFn) {
+  const [queue, setQueue] = useState<UploadEntry[]>([]);
+
+  const enqueue = useCallback((id: string, uri: string) => {
+    setQueue((prev) => {
+      if (prev.some((e) => e.id === id)) return prev;
+      return [...prev, { id, uri, status: "pending" }];
+    });
+  }, []);
+
+  const attempt = useCallback(
+    async (id: string) => {
+      const entry = queue.find((e) => e.id === id);
+      if (!entry || entry.status === "done" || entry.status === "uploading") return;
+
+      setQueue((prev) =>
+        prev.map((e) => (e.id === id ? { ...e, status: "uploading", error: undefined } : e))
+      );
+
+      try {
+        await uploadFn(entry.uri);
+        setQueue((prev) =>
+          prev.map((e) => (e.id === id ? { ...e, status: "done" } : e))
+        );
+      } catch (err) {
+        const error = err instanceof Error ? err.message : "Upload failed";
+        setQueue((prev) =>
+          prev.map((e) => (e.id === id ? { ...e, status: "failed", error } : e))
+        );
+      }
+    },
+    [queue, uploadFn]
+  );
+
+  const retry = useCallback((id: string) => attempt(id), [attempt]);
+
+  const failed = queue.filter((e) => e.status === "failed");
+  const pending = queue.filter((e) => e.status === "pending");
+
+  return { queue, enqueue, retry, attempt, failed, pending };
+}

--- a/apps/mobile/src/utils/accessibility.ts
+++ b/apps/mobile/src/utils/accessibility.ts
@@ -1,0 +1,52 @@
+/**
+ * Accessibility helpers for auth, reporting, and discovery flows (issue #213).
+ * Centralises a11y labels, minimum hit-target sizes, and contrast tokens
+ * so they are not duplicated per component.
+ */
+
+/** Minimum touch target size per WCAG 2.5.5 (44×44 pt) */
+export const MIN_HIT_SLOP = { top: 8, bottom: 8, left: 8, right: 8 } as const;
+export const MIN_TOUCH_SIZE = 44;
+
+/** Semantic labels for critical controls */
+export const A11Y_LABELS = {
+  submitReport: "Submit report",
+  retryUpload: "Retry failed upload",
+  openAttachment: "Open attachment preview",
+  closePreview: "Close preview",
+  signIn: "Sign in",
+  signOut: "Sign out",
+  sendOtp: "Send one-time password",
+  verifyOtp: "Verify one-time password",
+  nearbyFeed: "Nearby reports feed",
+  mapView: "Map view",
+} as const;
+
+/** Contrast-safe colour tokens for status chips and buttons */
+export const STATUS_COLORS: Record<string, { bg: string; text: string }> = {
+  open: { bg: "#1a56db", text: "#ffffff" },
+  resolved: { bg: "#057a55", text: "#ffffff" },
+  pending: { bg: "#c27803", text: "#ffffff" },
+  rejected: { bg: "#c81e1e", text: "#ffffff" },
+};
+
+/**
+ * Returns accessible props for a pressable element.
+ * Ensures label and role are always set.
+ */
+export function a11yButton(label: string, hint?: string) {
+  return {
+    accessible: true,
+    accessibilityRole: "button" as const,
+    accessibilityLabel: label,
+    ...(hint ? { accessibilityHint: hint } : {}),
+    hitSlop: MIN_HIT_SLOP,
+  };
+}
+
+/**
+ * Remaining accessibility debt (to be resolved in follow-up sprints):
+ * - Map pins lack individual screen-reader labels
+ * - OTP digit inputs need grouped accessibilityLabel
+ * - Dark-mode contrast for secondary text not yet audited
+ */

--- a/apps/mobile/src/utils/format.ts
+++ b/apps/mobile/src/utils/format.ts
@@ -1,0 +1,56 @@
+/** Locale-aware time and distance formatting utilities (issue #214) */
+
+const MINUTE = 60;
+const HOUR = 3600;
+const DAY = 86400;
+
+/**
+ * Returns a human-readable relative time string from a timestamp.
+ * Handles null/undefined safely.
+ */
+export function formatRelativeTime(timestamp: string | number | null | undefined): string {
+  if (!timestamp) return "Unknown time";
+
+  const now = Date.now();
+  const then = new Date(timestamp).getTime();
+  if (isNaN(then)) return "Invalid date";
+
+  const diff = Math.floor((now - then) / 1000);
+
+  if (diff < MINUTE) return "Just now";
+  if (diff < HOUR) return `${Math.floor(diff / MINUTE)}m ago`;
+  if (diff < DAY) return `${Math.floor(diff / HOUR)}h ago`;
+  if (diff < DAY * 7) return `${Math.floor(diff / DAY)}d ago`;
+
+  return new Date(then).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+/**
+ * Returns a formatted absolute date/time string.
+ */
+export function formatAbsoluteTime(timestamp: string | number | null | undefined): string {
+  if (!timestamp) return "—";
+  const d = new Date(timestamp);
+  if (isNaN(d.getTime())) return "—";
+  return d.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/**
+ * Formats a distance in meters to a readable string.
+ * Uses km above 1000 m, otherwise meters.
+ */
+export function formatDistance(meters: number | null | undefined): string {
+  if (meters == null || isNaN(meters)) return "—";
+  if (meters < 1000) return `${Math.round(meters)} m`;
+  return `${(meters / 1000).toFixed(1)} km`;
+}


### PR DESCRIPTION
Closes #211, closes #212, closes #213, closes #214

- **#211** — adds `useUploadRetry` hook that tracks per-file upload state, prevents duplicate uploads on retry, and exposes failed entries with error messages
- **#212** — adds `AttachmentCarousel` component with horizontal scroll, tap-to-fullscreen modal, and graceful handling of broken image URLs
- **#213** — adds `accessibility.ts` with centralised a11y labels, contrast-safe status-chip colours, `a11yButton` helper, and a documented debt list for follow-up
- **#214** — adds `format.ts` with `formatRelativeTime`, `formatAbsoluteTime`, and `formatDistance` utilities; null/invalid inputs handled safely throughout