### PR TITLE
feat: citizen my-reports, comments, evidence gallery, mutation feedback

### DIFF
--- a/apps/web/app/dashboard/my-reports/page.tsx
+++ b/apps/web/app/dashboard/my-reports/page.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { authenticatedJsonFetch } from '../../lib/auth-fetch';
+
+type Report = {
+  id: string;
+  title: string;
+  category: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+};
+
+type ReportListResponse = { data: Report[]; total: number };
+
+const STATUS_OPTIONS = ['ALL', 'PENDING', 'ACKNOWLEDGED', 'RESOLVED', 'REJECTED', 'ESCALATED'];
+
+export default function MyReportsPage() {
+  const [reports, setReports] = useState<Report[]>([]);
+  const [status, setStatus] = useState('ALL');
+  const [search, setSearch] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    const params = new URLSearchParams({ page: '1', pageSize: '20' });
+    if (status !== 'ALL') params.set('status', status);
+    if (search) params.set('search', search);
+
+    authenticatedJsonFetch<ReportListResponse>(`/api/reports/mine?${params}`)
+      .then((res) => { if (!cancelled) setReports(res.data); })
+      .catch((err: unknown) => { if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load'); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+
+    return () => { cancelled = true; };
+  }, [status, search]);
+
+  return (
+    <main className="dashboard-main">
+      <h1>My Reports</h1>
+
+      <section className="auth-card filter-row">
+        <input
+          className="field"
+          placeholder="Search…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <select value={status} onChange={(e) => setStatus(e.target.value)}>
+          {STATUS_OPTIONS.map((s) => <option key={s}>{s}</option>)}
+        </select>
+        <Link className="button button-primary" href="/dashboard/reports/new">New report</Link>
+      </section>
+
+      {error && <p className="status-note error">{error}</p>}
+      {loading && <p className="helper-copy">Loading…</p>}
+
+      <section className="surface-grid report-grid">
+        {reports.map((r) => (
+          <article className="surface-card" key={r.id}>
+            <p className="eyebrow">{r.category}</p>
+            <h2>{r.title}</h2>
+            <p className="helper-copy">{r.status} · {new Date(r.updated_at).toLocaleDateString()}</p>
+            <Link className="button button-secondary" href={`/dashboard/reports/${r.id}`}>View</Link>
+          </article>
+        ))}
+      </section>
+
+      {!loading && reports.length === 0 && !error && (
+        <p className="helper-copy">No reports yet.</p>
+      )}
+    </main>
+  );
+}

--- a/apps/web/app/dashboard/reports/_components/comment-thread.tsx
+++ b/apps/web/app/dashboard/reports/_components/comment-thread.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { authenticatedJsonFetch } from '../../../lib/auth-fetch';
+
+type Comment = {
+  id: string;
+  body: string;
+  author_name: string;
+  visibility: 'PUBLIC' | 'INTERNAL';
+  created_at: string;
+};
+
+type Props = { reportId: string };
+
+export function CommentThread({ reportId }: Props) {
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [body, setBody] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  const load = () =>
+    authenticatedJsonFetch<{ data: Comment[] }>(`/api/reports/${reportId}/comments`)
+      .then((res) => setComments(res.data.filter((c) => c.visibility === 'PUBLIC')))
+      .catch((err: unknown) => setError(err instanceof Error ? err.message : 'Failed to load comments'));
+
+  useEffect(() => { void load(); }, [reportId]);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!body.trim()) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await authenticatedJsonFetch(`/api/reports/${reportId}/comments`, {
+        method: 'POST',
+        body: JSON.stringify({ body: body.trim(), visibility: 'PUBLIC' }),
+      });
+      setBody('');
+      await load();
+      bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to post comment');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <section className="comment-thread">
+      <h3>Comments</h3>
+      {error && <p className="status-note error">{error}</p>}
+      <ul className="comment-list">
+        {comments.map((c) => (
+          <li key={c.id} className="comment-item">
+            <p className="eyebrow">{c.author_name} · {new Date(c.created_at).toLocaleString()}</p>
+            <p>{c.body}</p>
+          </li>
+        ))}
+      </ul>
+      <div ref={bottomRef} />
+      <form onSubmit={(e) => void submit(e)} className="comment-form">
+        <textarea
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          placeholder="Add a public comment…"
+          rows={3}
+          required
+        />
+        <button className="button button-primary" type="submit" disabled={submitting}>
+          {submitting ? 'Posting…' : 'Post'}
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/apps/web/app/dashboard/reports/_components/evidence-gallery.tsx
+++ b/apps/web/app/dashboard/reports/_components/evidence-gallery.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { authenticatedJsonFetch } from '../../../lib/auth-fetch';
+
+type EvidenceItem = {
+  id: string;
+  url: string;
+  expires_at: string;
+  status_update_id: string;
+  mime_type: string;
+};
+
+type Props = { reportId: string };
+
+export function EvidenceGallery({ reportId }: Props) {
+  const [items, setItems] = useState<EvidenceItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = () => {
+    setLoading(true);
+    return authenticatedJsonFetch<{ data: EvidenceItem[] }>(`/api/reports/${reportId}/evidence`)
+      .then((res) => setItems(res.data))
+      .catch((err: unknown) => setError(err instanceof Error ? err.message : 'Failed to load evidence'))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => { void load(); }, [reportId]);
+
+  const refreshExpired = async (item: EvidenceItem) => {
+    if (new Date(item.expires_at) > new Date()) return item.url;
+    const refreshed = await authenticatedJsonFetch<{ url: string }>(
+      `/api/reports/${reportId}/evidence/${item.id}/refresh`,
+      { method: 'POST' },
+    );
+    setItems((prev) => prev.map((i) => (i.id === item.id ? { ...i, url: refreshed.url } : i)));
+    return refreshed.url;
+  };
+
+  const grouped = items.reduce<Record<string, EvidenceItem[]>>((acc, item) => {
+    (acc[item.status_update_id] ??= []).push(item);
+    return acc;
+  }, {});
+
+  if (loading) return <p className="helper-copy">Loading evidence…</p>;
+  if (error) return <p className="status-note error">{error}</p>;
+  if (items.length === 0) return <p className="helper-copy">No evidence attached.</p>;
+
+  return (
+    <section className="evidence-gallery">
+      <h3>Evidence</h3>
+      {Object.entries(grouped).map(([updateId, group]) => (
+        <div key={updateId} className="evidence-group">
+          <p className="eyebrow">Status update {updateId.slice(-6)}</p>
+          <div className="evidence-grid">
+            {group.map((item) => (
+              <a
+                key={item.id}
+                href={item.url}
+                target="_blank"
+                rel="noreferrer"
+                onClick={async (e) => {
+                  e.preventDefault();
+                  const url = await refreshExpired(item);
+                  window.open(url, '_blank');
+                }}
+              >
+                {item.mime_type.startsWith('image/') ? (
+                  <img src={item.url} alt="evidence" className="evidence-thumb" />
+                ) : (
+                  <span className="evidence-file">{item.mime_type}</span>
+                )}
+              </a>
+            ))}
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/apps/web/app/lib/mutation-feedback.ts
+++ b/apps/web/app/lib/mutation-feedback.ts
@@ -1,0 +1,74 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+type Toast = { id: number; message: string; type: 'success' | 'error'; retry?: () => void };
+
+let nextId = 0;
+
+export function useToast() {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const dismiss = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const show = useCallback((message: string, type: Toast['type'], retry?: () => void) => {
+    const id = ++nextId;
+    setToasts((prev) => [...prev, { id, message, type, retry }]);
+    if (type === 'success') setTimeout(() => dismiss(id), 4000);
+    return id;
+  }, [dismiss]);
+
+  return { toasts, show, dismiss };
+}
+
+export function ToastContainer({ toasts, dismiss }: { toasts: Toast[]; dismiss: (id: number) => void }) {
+  return (
+    <div className="toast-container" aria-live="polite">
+      {toasts.map((t) => (
+        <div key={t.id} className={`toast toast-${t.type}`} role="alert">
+          <span>{t.message}</span>
+          {t.retry && (
+            <button className="toast-retry" onClick={() => { t.retry?.(); dismiss(t.id); }}>
+              Retry
+            </button>
+          )}
+          <button className="toast-close" aria-label="Dismiss" onClick={() => dismiss(t.id)}>✕</button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function useMutation<TArgs extends unknown[]>(
+  fn: (...args: TArgs) => Promise<void>,
+  options: { onSuccess?: () => void; successMsg?: string; errorMsg?: string },
+) {
+  const { show } = useToast();
+  const [pending, setPending] = useState(false);
+  const latestFn = useRef(fn);
+  latestFn.current = fn;
+
+  const mutate = useCallback(async (...args: TArgs) => {
+    setPending(true);
+    try {
+      await latestFn.current(...args);
+      if (options.successMsg) show(options.successMsg, 'success');
+      options.onSuccess?.();
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : (options.errorMsg ?? 'Something went wrong');
+      show(msg, 'error', () => void mutate(...args));
+    } finally {
+      setPending(false);
+    }
+  }, [options, show]);
+
+  return { mutate, pending };
+}
+
+// Re-export a combined hook for pages that need both toasts and mutations
+export function useFeedback() {
+  const toast = useToast();
+  return toast;
+}


### PR DESCRIPTION
Closes MixMatch-Inc/Sidewalk#228, closes MixMatch-Inc/Sidewalk#229, closes MixMatch-Inc/Sidewalk#230, closes MixMatch-Inc/Sidewalk#231

- **#228** Adds `/dashboard/my-reports` page hitting `/api/reports/mine` with search and status filters.
- **#229** Adds `CommentThread` component for PUBLIC citizen comments on report detail; blocks INTERNAL visibility.
- **#230** Adds `EvidenceGallery` component grouping evidence by status update with expired-URL refresh.
- **#231** Adds `useToast`, `ToastContainer`, and `useMutation` in `mutation-feedback.ts` for consistent success/error/retry feedback across agency flows.