### PR TITLE
feat: add proof verification, public map, admin config and analytics pages (#224-227)

### DIFF
--- a/apps/web/app/auth/admin/analytics/page.tsx
+++ b/apps/web/app/auth/admin/analytics/page.tsx
@@ -1,0 +1,216 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { fetchAnalytics, AnalyticsData } from '@/lib/api/analytics';
+
+const RANGE_OPTIONS = [
+  { label: 'Last 7 days',  value: 7  },
+  { label: 'Last 30 days', value: 30 },
+  { label: 'Last 90 days', value: 90 },
+];
+
+const STATUS_COLORS: Record<string, string> = {
+  open:     '#E24B4A',
+  pending:  '#BA7517',
+  resolved: '#639922',
+  rejected: '#888780',
+};
+
+export default function AnalyticsPage() {
+  const [range, setRange]       = useState(30);
+  const [data, setData]         = useState<AnalyticsData | null>(null);
+  const [loading, setLoading]   = useState(true);
+  const [error, setError]       = useState('');
+
+  useEffect(() => {
+    setLoading(true);
+    setError('');
+    fetchAnalytics(range)
+      .then(setData)
+      .catch(e => setError(e instanceof Error ? e.message : 'Failed to load'))
+      .finally(() => setLoading(false));
+  }, [range]);
+
+  return (
+    <main className="max-w-4xl mx-auto px-4 py-8 space-y-6">
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <h1 className="text-2xl font-medium">Analytics</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            System health, throughput, and SLA metrics.
+          </p>
+        </div>
+        <select
+          className="select"
+          value={range}
+          onChange={e => setRange(Number(e.target.value))}
+        >
+          {RANGE_OPTIONS.map(o => (
+            <option key={o.value} value={o.value}>{o.label}</option>
+          ))}
+        </select>
+      </div>
+
+      {error && (
+        <div className="card border-destructive text-sm text-destructive">{error}</div>
+      )}
+
+      {loading && <div className="text-sm text-muted-foreground">Loading…</div>}
+
+      {data && (
+        <>
+          {/* Summary metrics */}
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+            <MetricCard
+              label="Total reports"
+              value={data.summary.totalReports.toLocaleString()}
+              sub={`${data.summary.periodChange >= 0 ? '+' : ''}${data.summary.periodChange}% vs prior period`}
+            />
+            <MetricCard
+              label="Open backlog"
+              value={data.summary.openBacklog.toLocaleString()}
+              sub={`${((data.summary.openBacklog / data.summary.totalReports) * 100).toFixed(1)}% of total`}
+            />
+            <MetricCard
+              label="SLA breaches"
+              value={data.summary.slaBreaches.toLocaleString()}
+              sub={`${((data.summary.slaBreaches / data.summary.totalReports) * 100).toFixed(1)}% breach rate`}
+            />
+            <MetricCard
+              label="Avg resolution"
+              value={`${data.summary.avgResolutionDays}d`}
+              sub="Median time to resolve"
+            />
+          </div>
+
+          {/* Status + Category breakdowns */}
+          <div className="grid md:grid-cols-2 gap-6">
+            <div className="card space-y-3">
+              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">By status</p>
+              {data.byStatus.map(s => (
+                <BarRow
+                  key={s.status}
+                  label={s.status}
+                  count={s.count}
+                  pct={s.pct}
+                  color={STATUS_COLORS[s.status]}
+                />
+              ))}
+            </div>
+            <div className="card space-y-3">
+              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">By category</p>
+              {data.byCategory.map(c => (
+                <BarRow
+                  key={c.category}
+                  label={c.category}
+                  count={c.count}
+                  pct={c.pct}
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* District table */}
+          <div className="card p-0 overflow-hidden">
+            <div className="grid grid-cols-[1fr_60px_70px_80px_100px] text-xs font-medium text-muted-foreground uppercase tracking-wide px-3 py-2 bg-muted">
+              <span>District</span>
+              <span>Open</span>
+              <span>Pending</span>
+              <span>Resolved</span>
+              <span>SLA breach</span>
+            </div>
+            {data.byDistrict.map(d => {
+              const total = d.open + d.pending + d.resolved;
+              return (
+                <div
+                  key={d.district}
+                  className="grid grid-cols-[1fr_60px_70px_80px_100px] px-3 py-2.5 text-sm border-t"
+                >
+                  <span>{d.district}</span>
+                  <span className="text-destructive">{d.open}</span>
+                  <span className="text-warning-foreground">{d.pending}</span>
+                  <span className="text-success-foreground">{d.resolved}</span>
+                  <span className="text-destructive">
+                    {d.slaBreaches}{' '}
+                    <span className="text-muted-foreground text-xs">
+                      ({((d.slaBreaches / total) * 100).toFixed(1)}%)
+                    </span>
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Daily volume trend */}
+          <div className="card">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground mb-3">
+              Daily volume
+            </p>
+            <TrendChart data={data.dailyVolume} />
+          </div>
+        </>
+      )}
+    </main>
+  );
+}
+
+/* ---- Sub-components ---- */
+
+function MetricCard({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div className="bg-muted rounded-md p-4">
+      <p className="text-xs text-muted-foreground mb-1">{label}</p>
+      <p className="text-2xl font-medium">{value}</p>
+      {sub && <p className="text-xs text-muted-foreground mt-1">{sub}</p>}
+    </div>
+  );
+}
+
+function BarRow({
+  label, count, pct, color,
+}: {
+  label: string; count: number; pct: number; color?: string;
+}) {
+  return (
+    <div>
+      <div className="flex justify-between text-sm mb-1">
+        <span className="capitalize">{label}</span>
+        <span className="text-muted-foreground tabular-nums">
+          {count.toLocaleString()} ({pct}%)
+        </span>
+      </div>
+      <div className="bg-muted rounded-full h-1.5 overflow-hidden">
+        <div
+          className="h-full rounded-full transition-all duration-500"
+          style={{ width: `${pct}%`, background: color ?? 'currentColor', opacity: color ? 1 : 0.4 }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function TrendChart({ data }: { data: { date: string; count: number }[] }) {
+  const max = Math.max(...data.map(d => d.count), 1);
+  return (
+    <div className="space-y-1">
+      <div className="flex items-end gap-1 h-20">
+        {data.map((d, i) => (
+          <div
+            key={i}
+            title={`${d.date}: ${d.count} reports`}
+            className="flex-1 bg-muted-foreground/20 rounded-sm hover:bg-primary/30 transition-colors cursor-default"
+            style={{ height: `${Math.round((d.count / max) * 100)}%` }}
+          />
+        ))}
+      </div>
+      <div className="flex gap-1">
+        {data.map((d, i) => (
+          <div key={i} className="flex-1 text-center text-[10px] text-muted-foreground">
+            {(i === 0 || i === Math.floor(data.length / 2) || i === data.length - 1)
+              ? new Date(d.date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })
+              : ''}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/auth/admin/config/page.tsx
+++ b/apps/web/app/auth/admin/config/page.tsx
@@ -1,0 +1,208 @@
+'use client';
+import { useState, useEffect } from 'react';
+import {
+  fetchConfig, saveConfig, fetchAuditLog,
+  SidewalkConfig, AuditEntry, CONFIG_DEFAULTS,
+} from '@/lib/api/config';
+
+export default function AdminConfigPage() {
+  const [config, setConfig]   = useState<SidewalkConfig>(CONFIG_DEFAULTS);
+  const [audit, setAudit]     = useState<AuditEntry[]>([]);
+  const [dirty, setDirty]     = useState(false);
+  const [saving, setSaving]   = useState(false);
+  const [toast, setToast]     = useState<{ type: 'success' | 'error'; msg: string } | null>(null);
+
+  useEffect(() => {
+    fetchConfig()
+      .then(c => setConfig(c))
+      .catch(() => setConfig(CONFIG_DEFAULTS));   // safe defaults on missing config
+    fetchAuditLog().then(setAudit);
+  }, []);
+
+  function mark<T>(updater: (prev: SidewalkConfig) => SidewalkConfig) {
+    setConfig(updater);
+    setDirty(true);
+  }
+
+  function toggleCategory(id: string, enabled: boolean) {
+    mark(prev => ({
+      ...prev,
+      categories: prev.categories.map(c => c.id === id ? { ...c, enabled } : c),
+    }));
+  }
+
+  function setModeration<K extends keyof SidewalkConfig['moderation']>(
+    key: K, value: SidewalkConfig['moderation'][K]
+  ) {
+    mark(prev => ({
+      ...prev,
+      moderation: { ...prev.moderation, [key]: value },
+    }));
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    try {
+      await saveConfig(config);
+      setDirty(false);
+      showToast('success', 'Settings saved. Changes will propagate on next page refresh.');
+    } catch (e) {
+      showToast('error', e instanceof Error ? e.message : 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function handleReset() {
+    setConfig(CONFIG_DEFAULTS);
+    setDirty(true);
+    showToast('success', 'Reset to defaults. Save to confirm.');
+  }
+
+  function showToast(type: 'success' | 'error', msg: string) {
+    setToast({ type, msg });
+    setTimeout(() => setToast(null), 4000);
+  }
+
+  const mod = config.moderation;
+
+  return (
+    <main className="max-w-3xl mx-auto px-4 py-8 space-y-6">
+      <div>
+        <h1 className="text-2xl font-medium">Configuration</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Taxonomy and moderation settings. Updated settings propagate to relevant UIs after refresh.
+        </p>
+      </div>
+
+      <div className="grid md:grid-cols-2 gap-6">
+        {/* Category enablement */}
+        <div className="card space-y-3">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Category enablement
+          </p>
+          {config.categories.map(cat => (
+            <label key={cat.id} className="flex items-center gap-3 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={cat.enabled}
+                onChange={e => toggleCategory(cat.id, e.target.checked)}
+                className="accent-primary"
+              />
+              <span className="text-sm flex-1">{cat.label}</span>
+              {!cat.enabled && (
+                <span className="badge badge-secondary text-[11px]">disabled</span>
+              )}
+            </label>
+          ))}
+        </div>
+
+        {/* Moderation thresholds */}
+        <div className="card space-y-5">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Moderation thresholds
+          </p>
+
+          <SliderField
+            label="Auto-flag score"
+            desc="Reports above this confidence score are flagged for review."
+            min={0} max={1} step={0.01}
+            value={mod.autoFlagScore}
+            format={v => v.toFixed(2)}
+            onChange={v => setModeration('autoFlagScore', v)}
+          />
+
+          <SliderField
+            label="Auto-reject score"
+            desc="Reports above this score are rejected without human review."
+            min={0} max={1} step={0.01}
+            value={mod.autoRejectScore}
+            format={v => v.toFixed(2)}
+            onChange={v => setModeration('autoRejectScore', v)}
+          />
+
+          <SliderField
+            label="SLA warning (hours)"
+            desc="Reports older than this without resolution trigger a warning."
+            min={12} max={168} step={1}
+            value={mod.slaWarningHours}
+            format={v => String(Math.round(v))}
+            onChange={v => setModeration('slaWarningHours', Math.round(v))}
+          />
+        </div>
+      </div>
+
+      {/* Audit log */}
+      <div className="card">
+        <div className="flex items-center justify-between mb-3">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Audit log
+          </p>
+          <span className="badge badge-secondary">Last {audit.length} changes</span>
+        </div>
+        {audit.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No audit entries yet.</p>
+        ) : (
+          <div className="divide-y">
+            {audit.map((a, i) => (
+              <div key={i} className="flex items-center justify-between py-2 text-sm">
+                <div>
+                  <p>{a.change}</p>
+                  <p className="text-xs text-muted-foreground">{a.actor}</p>
+                </div>
+                <p className="text-xs text-muted-foreground whitespace-nowrap">{a.timestamp}</p>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center justify-end gap-3">
+        <button className="btn" onClick={handleReset}>Reset to defaults</button>
+        <button
+          className="btn btn-primary"
+          onClick={handleSave}
+          disabled={saving || !dirty}
+        >
+          {saving ? 'Saving…' : 'Save changes'}
+        </button>
+      </div>
+
+      {/* Toast */}
+      {toast && (
+        <div className={`rounded-md p-3 text-sm ${
+          toast.type === 'success'
+            ? 'bg-success/10 border border-success/30 text-success-foreground'
+            : 'bg-destructive/10 border border-destructive/30 text-destructive'
+        }`}>
+          {toast.msg}
+        </div>
+      )}
+    </main>
+  );
+}
+
+function SliderField({
+  label, desc, min, max, step, value, format, onChange,
+}: {
+  label: string; desc: string;
+  min: number; max: number; step: number; value: number;
+  format: (v: number) => string;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between">
+        <label className="text-xs font-medium">{label}</label>
+        <span className="text-xs font-medium tabular-nums">{format(value)}</span>
+      </div>
+      <input
+        type="range" min={min} max={max} step={step} value={value}
+        onChange={e => onChange(parseFloat(e.target.value))}
+        className="w-full"
+      />
+      <p className="text-xs text-muted-foreground">{desc}</p>
+    </div>
+  );
+}

--- a/apps/web/app/lib/api/analytics.ts
+++ b/apps/web/app/lib/api/analytics.ts
@@ -1,0 +1,50 @@
+export interface AnalyticsSummary {
+  totalReports: number;
+  openBacklog: number;
+  slaBreaches: number;
+  avgResolutionDays: number;
+  periodChange: number;         // % change vs previous period
+}
+
+export interface StatusBreakdown {
+  status: string;
+  count: number;
+  pct: number;
+}
+
+export interface CategoryBreakdown {
+  category: string;
+  count: number;
+  pct: number;
+}
+
+export interface DistrictRow {
+  district: string;
+  open: number;
+  pending: number;
+  resolved: number;
+  slaBreaches: number;
+}
+
+export interface DailyVolume {
+  date: string;   // ISO date string
+  count: number;
+}
+
+export interface AnalyticsData {
+  summary: AnalyticsSummary;
+  byStatus: StatusBreakdown[];
+  byCategory: CategoryBreakdown[];
+  byDistrict: DistrictRow[];
+  dailyVolume: DailyVolume[];
+}
+
+const BASE = process.env.NEXT_PUBLIC_API_URL ?? '';
+
+export async function fetchAnalytics(rangeDays: number): Promise<AnalyticsData> {
+  const res = await fetch(`${BASE}/api/admin/analytics?range=${rangeDays}d`, {
+    cache: 'no-store',
+  });
+  if (!res.ok) throw new Error(`Analytics fetch failed: ${res.status}`);
+  return res.json();
+}

--- a/apps/web/app/lib/api/config.ts
+++ b/apps/web/app/lib/api/config.ts
@@ -1,0 +1,66 @@
+// lib/api/config.ts  — matches S1-BE-23 / S2-BE-08
+
+export interface CategoryConfig {
+  id: string;
+  label: string;
+  enabled: boolean;
+}
+
+export interface ModerationConfig {
+  autoFlagScore: number;       // 0–1
+  autoRejectScore: number;     // 0–1
+  slaWarningHours: number;
+}
+
+export interface SidewalkConfig {
+  categories: CategoryConfig[];
+  moderation: ModerationConfig;
+}
+
+export interface AuditEntry {
+  actor: string;
+  change: string;
+  timestamp: string;
+}
+
+const BASE = process.env.NEXT_PUBLIC_API_URL ?? '';
+
+export async function fetchConfig(): Promise<SidewalkConfig> {
+  const res = await fetch(`${BASE}/api/admin/config`, { cache: 'no-store' });
+  if (!res.ok) throw new Error(`Config fetch failed: ${res.status}`);
+  return res.json();
+}
+
+export async function saveConfig(config: SidewalkConfig): Promise<void> {
+  const res = await fetch(`${BASE}/api/admin/config`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(config),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err?.message ?? `Save failed: ${res.status}`);
+  }
+}
+
+export async function fetchAuditLog(): Promise<AuditEntry[]> {
+  const res = await fetch(`${BASE}/api/admin/config/audit`, { cache: 'no-store' });
+  if (!res.ok) return [];
+  return res.json();
+}
+
+export const CONFIG_DEFAULTS: SidewalkConfig = {
+  categories: [
+    { id: 'pothole', label: 'Pothole', enabled: true },
+    { id: 'lighting', label: 'Street lighting', enabled: true },
+    { id: 'graffiti', label: 'Graffiti', enabled: true },
+    { id: 'drainage', label: 'Drainage', enabled: false },
+    { id: 'noise', label: 'Noise complaint', enabled: false },
+    { id: 'parking', label: 'Illegal parking', enabled: true },
+  ],
+  moderation: {
+    autoFlagScore: 0.75,
+    autoRejectScore: 0.95,
+    slaWarningHours: 48,
+  },
+};

--- a/apps/web/app/lib/api/map.ts
+++ b/apps/web/app/lib/api/map.ts
@@ -1,0 +1,44 @@
+export interface PublicReport {
+  id: string;
+  lat: number;
+  lng: number;
+  status: 'open' | 'pending' | 'resolved';
+  category: string;
+  shortDescription: string;
+  district: string;
+  createdAt: string;
+}
+
+export interface MapBounds {
+  north: number;
+  south: number;
+  east: number;
+  west: number;
+}
+
+const BASE = process.env.NEXT_PUBLIC_API_URL ?? '';
+
+export async function fetchPublicReports(
+  bounds: MapBounds,
+  filters?: { status?: string; category?: string; district?: string }
+): Promise<PublicReport[]> {
+  const params = new URLSearchParams({
+    north: String(bounds.north),
+    south: String(bounds.south),
+    east: String(bounds.east),
+    west: String(bounds.west),
+    ...(filters?.status && filters.status !== 'all' ? { status: filters.status } : {}),
+    ...(filters?.category && filters.category !== 'all' ? { category: filters.category } : {}),
+    ...(filters?.district && filters.district !== 'all' ? { district: filters.district } : {}),
+  });
+
+  const res = await fetch(`${BASE}/api/reports/public?${params}`, { cache: 'no-store' });
+  if (!res.ok) throw new Error(`Map fetch failed: ${res.status}`);
+  return res.json();
+}
+
+export async function fetchPublicReportDetail(id: string): Promise<PublicReport> {
+  const res = await fetch(`${BASE}/api/reports/public/${id}`, { cache: 'no-store' });
+  if (!res.ok) throw new Error(`Report fetch failed: ${res.status}`);
+  return res.json();
+}

--- a/apps/web/app/lib/api/proof.ts
+++ b/apps/web/app/lib/api/proof.ts
@@ -1,0 +1,29 @@
+export type ProofStatus = 'verified' | 'pending' | 'failed' | 'not_found';
+
+export interface ProofRecord {
+  reportId: string;
+  snapshotHash: string;
+  txHash: string | null;
+  chain: string;
+  blockNumber: number | null;
+  timestamp: string;
+  status: ProofStatus;
+  failReason?: string;
+  explorerBaseUrl?: string;
+  category?: string;
+  district?: string;
+}
+
+const BASE = process.env.NEXT_PUBLIC_API_URL ?? '';
+
+export async function fetchProof(idOrHash: string): Promise<ProofRecord | null> {
+  const isHash = idOrHash.startsWith('0x');
+  const endpoint = isHash
+    ? `/api/proofs/tx/${idOrHash}`
+    : `/api/proofs/${idOrHash}`;
+
+  const res = await fetch(`${BASE}${endpoint}`, { cache: 'no-store' });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`Proof fetch failed: ${res.status}`);
+  return res.json();
+}

--- a/apps/web/app/map/page.tsx
+++ b/apps/web/app/map/page.tsx
@@ -1,0 +1,204 @@
+'use client';
+import { useState, useEffect, useCallback } from 'react';
+import { fetchPublicReports, fetchPublicReportDetail, PublicReport, MapBounds } from '@/lib/api/map';
+
+// Default bounds — replace with your pilot city's bounding box
+const DEFAULT_BOUNDS: MapBounds = {
+  north: 51.55, south: 51.45,
+  east: -0.08,  west: -0.18,
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  open:     '#E24B4A',
+  pending:  '#BA7517',
+  resolved: '#639922',
+};
+
+export default function MapPage() {
+  const [reports, setReports]           = useState<PublicReport[]>([]);
+  const [selected, setSelected]         = useState<PublicReport | null>(null);
+  const [statusFilter, setStatusFilter] = useState('all');
+  const [catFilter, setCatFilter]       = useState('all');
+  const [districtFilter, setDistrictFilter] = useState('all');
+  const [loading, setLoading]           = useState(true);
+  const [error, setError]               = useState('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const data = await fetchPublicReports(DEFAULT_BOUNDS, {
+        status: statusFilter,
+        category: catFilter,
+        district: districtFilter,
+      });
+      setReports(data);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load reports');
+    } finally {
+      setLoading(false);
+    }
+  }, [statusFilter, catFilter, districtFilter]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const categories = ['all', 'pothole', 'lighting', 'graffiti', 'drainage', 'other'];
+  const districts  = ['all', 'north', 'south', 'east', 'west'];
+
+  return (
+    <main className="flex flex-col gap-4 max-w-4xl mx-auto px-4 py-8">
+      <div>
+        <h1 className="text-2xl font-medium">Public map</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Browse reported issues in your area. Only public information is shown.
+        </p>
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-wrap gap-2 items-center">
+        <select className="select" value={statusFilter} onChange={e => setStatusFilter(e.target.value)}>
+          <option value="all">All statuses</option>
+          <option value="open">Open</option>
+          <option value="pending">Pending</option>
+          <option value="resolved">Resolved</option>
+        </select>
+        <select className="select" value={catFilter} onChange={e => setCatFilter(e.target.value)}>
+          {categories.map(c => (
+            <option key={c} value={c}>{c === 'all' ? 'All categories' : c}</option>
+          ))}
+        </select>
+        <select className="select" value={districtFilter} onChange={e => setDistrictFilter(e.target.value)}>
+          {districts.map(d => (
+            <option key={d} value={d}>{d === 'all' ? 'All districts' : d + ' ward'}</option>
+          ))}
+        </select>
+        <div className="ml-auto flex items-center gap-3 text-xs text-muted-foreground">
+          {Object.entries(STATUS_COLORS).map(([s, color]) => (
+            <span key={s} className="flex items-center gap-1.5">
+              <span className="w-2 h-2 rounded-full inline-block" style={{ background: color }} />
+              {s}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* Map area */}
+      {/* TODO: replace this placeholder with your MapLibre / Leaflet / Google Maps component.
+          Pass reports, onMarkerClick, and bounds as props.
+          The MapCanvas below is a lightweight substitute for development. */}
+      <div className="card p-0 overflow-hidden">
+        <MapCanvas
+          reports={reports}
+          loading={loading}
+          onSelect={setSelected}
+          selected={selected}
+        />
+      </div>
+
+      {/* Selected report detail */}
+      {selected && (
+        <div className="card flex items-start justify-between gap-4">
+          <div>
+            <div className="flex items-center gap-2 mb-1">
+              <span className="font-medium text-sm">{selected.id}</span>
+              <StatusBadge status={selected.status} />
+            </div>
+            <p className="text-sm">{selected.shortDescription}</p>
+            <p className="text-xs text-muted-foreground mt-1">
+              {selected.category} · {selected.district} · {selected.createdAt}
+            </p>
+          </div>
+          <a href={`/reports/${selected.id}`} className="text-sm text-primary underline-offset-4 hover:underline whitespace-nowrap">
+            Full report →
+          </a>
+        </div>
+      )}
+
+      {/* Error */}
+      {error && (
+        <div className="card border-destructive text-sm text-destructive">{error}</div>
+      )}
+
+      {/* List view */}
+      <div className="card p-0 overflow-hidden">
+        <div className="grid grid-cols-[80px_1fr_100px_90px] text-xs font-medium text-muted-foreground uppercase tracking-wide px-3 py-2 bg-muted">
+          <span>ID</span><span>Description</span><span>Category</span><span>Status</span>
+        </div>
+        {loading && <p className="text-sm text-muted-foreground p-4">Loading…</p>}
+        {!loading && reports.length === 0 && (
+          <p className="text-sm text-muted-foreground p-4">No reports match the current filters.</p>
+        )}
+        {reports.map(r => (
+          <button
+            key={r.id}
+            onClick={() => setSelected(r)}
+            className="grid grid-cols-[80px_1fr_100px_90px] px-3 py-2.5 text-left text-sm border-t w-full hover:bg-muted/50 transition-colors"
+          >
+            <span className="font-mono text-xs text-muted-foreground">{r.id}</span>
+            <span className="truncate">{r.shortDescription}</span>
+            <span className="text-muted-foreground">{r.category}</span>
+            <span><StatusBadge status={r.status} /></span>
+          </button>
+        ))}
+      </div>
+    </main>
+  );
+}
+
+/* ---- Lightweight dev-mode map canvas (replace with real map library) ---- */
+function MapCanvas({
+  reports, loading, onSelect, selected,
+}: {
+  reports: PublicReport[];
+  loading: boolean;
+  onSelect: (r: PublicReport) => void;
+  selected: PublicReport | null;
+}) {
+  return (
+    <div className="relative bg-muted h-80 w-full">
+      {loading && (
+        <div className="absolute inset-0 flex items-center justify-center text-sm text-muted-foreground">
+          Loading map…
+        </div>
+      )}
+      {/* Each report rendered as a proportional dot over a placeholder bg.
+          Replace this div with <MapLibreMap /> or <LeafletMap /> bound to reports. */}
+      {reports.map(r => (
+        <button
+          key={r.id}
+          onClick={() => onSelect(r)}
+          title={r.shortDescription}
+          style={{
+            position: 'absolute',
+            left: `${normalizeLng(r.lng)}%`,
+            top:  `${normalizeLat(r.lat)}%`,
+            width:  selected?.id === r.id ? 14 : 10,
+            height: selected?.id === r.id ? 14 : 10,
+            borderRadius: '50%',
+            background: STATUS_COLORS[r.status] ?? '#888',
+            border: selected?.id === r.id ? '2px solid white' : 'none',
+            transform: 'translate(-50%, -50%)',
+            cursor: 'pointer',
+            transition: 'all 0.15s',
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function normalizeLng(lng: number) {
+  return ((lng - DEFAULT_BOUNDS.west) / (DEFAULT_BOUNDS.east - DEFAULT_BOUNDS.west)) * 100;
+}
+function normalizeLat(lat: number) {
+  return ((DEFAULT_BOUNDS.north - lat) / (DEFAULT_BOUNDS.north - DEFAULT_BOUNDS.south)) * 100;
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const cls = {
+    open:     'badge-destructive',
+    pending:  'badge-warning',
+    resolved: 'badge-success',
+  }[status] ?? 'badge-secondary';
+  return <span className={`badge ${cls}`}>{status}</span>;
+}

--- a/apps/web/app/verify/page.tsx
+++ b/apps/web/app/verify/page.tsx
@@ -1,0 +1,212 @@
+'use client';
+import { useState } from 'react';
+import { fetchProof, ProofRecord } from '@/lib/api/proof';
+
+type State = 'idle' | 'loading' | 'found' | 'not_found' | 'error';
+
+export default function VerifyPage() {
+  const [query, setQuery] = useState('');
+  const [state, setState] = useState<State>('idle');
+  const [proof, setProof] = useState<ProofRecord | null>(null);
+  const [errorMsg, setErrorMsg] = useState('');
+
+  async function handleVerify(e: React.FormEvent) {
+    e.preventDefault();
+    const q = query.trim();
+    if (!q) return;
+    setState('loading');
+    try {
+      const result = await fetchProof(q);
+      if (!result) {
+        setState('not_found');
+      } else {
+        setProof(result);
+        setState('found');
+      }
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : 'Unknown error');
+      setState('error');
+    }
+  }
+
+  return (
+    <main className="max-w-2xl mx-auto px-4 py-12">
+      <h1 className="text-2xl font-medium mb-1">Proof verification</h1>
+      <p className="text-sm text-muted-foreground mb-8">
+        Enter a report ID or transaction hash to verify its proof. No sign-in required.
+      </p>
+
+      {/* Lookup form */}
+      <form onSubmit={handleVerify} className="flex gap-2 mb-8">
+        <input
+          type="text"
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+          placeholder="RPT-2024-001839 or 0x4a3f…"
+          className="flex-1 input"
+          autoComplete="off"
+          spellCheck={false}
+        />
+        <button type="submit" className="btn btn-primary" disabled={state === 'loading'}>
+          {state === 'loading' ? 'Checking…' : 'Verify'}
+        </button>
+      </form>
+
+      {/* States */}
+      {state === 'not_found' && <NotFound query={query} />}
+      {state === 'error' && <ErrorState message={errorMsg} />}
+      {state === 'found' && proof && <ProofResult proof={proof} />}
+    </main>
+  );
+}
+
+/* ---- Sub-components ---- */
+
+function NotFound({ query }: { query: string }) {
+  return (
+    <div className="card border-destructive">
+      <p className="font-medium mb-1">Not found</p>
+      <p className="text-sm text-muted-foreground">
+        No proof record matches <code className="font-mono text-xs">{query}</code>.
+        Check the ID in your confirmation message or try the full transaction hash.
+      </p>
+    </div>
+  );
+}
+
+function ErrorState({ message }: { message: string }) {
+  return (
+    <div className="card border-destructive">
+      <p className="font-medium mb-1">Verification error</p>
+      <p className="text-sm text-muted-foreground">{message}</p>
+    </div>
+  );
+}
+
+function ProofResult({ proof }: { proof: ProofRecord }) {
+  const statusConfig = {
+    verified: { label: 'Verified', className: 'badge-success' },
+    pending:  { label: 'Pending',  className: 'badge-warning' },
+    failed:   { label: 'Failed',   className: 'badge-destructive' },
+    not_found:{ label: 'Not found',className: 'badge-secondary' },
+  } as const;
+
+  const sc = statusConfig[proof.status];
+
+  return (
+    <div className="card space-y-4">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="font-medium text-base">{proof.reportId}</p>
+          <p className="text-sm text-muted-foreground">
+            {proof.category} · {proof.district} · {proof.timestamp}
+          </p>
+        </div>
+        <span className={`badge ${sc.className}`}>{sc.label}</span>
+      </div>
+
+      {/* Pending explanation */}
+      {proof.status === 'pending' && (
+        <div className="rounded-md bg-warning/10 border border-warning/30 p-3 text-sm text-warning-foreground">
+          This proof is being anchored to the chain. Anchoring typically completes within
+          5–15 minutes of submission. Refresh the page to check for updates.
+        </div>
+      )}
+
+      {/* Failed explanation */}
+      {proof.status === 'failed' && proof.failReason && (
+        <div className="rounded-md bg-destructive/10 border border-destructive/30 p-3 text-sm text-destructive">
+          {proof.failReason}
+        </div>
+      )}
+
+      {/* Proof steps */}
+      <div className="divide-y">
+        <ProofStep
+          num={1}
+          done
+          title="Snapshot hash recorded"
+          detail={proof.snapshotHash}
+          note="SHA-256 of report data at submission time."
+        />
+        <ProofStep
+          num={2}
+          done={!!proof.txHash}
+          pending={!proof.txHash && proof.status === 'pending'}
+          title="Transaction submitted"
+          detail={proof.txHash ?? 'Awaiting confirmation'}
+          note={proof.blockNumber ? `Block ${proof.blockNumber}` : undefined}
+        />
+        <ProofStep
+          num={3}
+          done={proof.status === 'verified'}
+          pending={proof.status === 'pending'}
+          failed={proof.status === 'failed'}
+          title="Chain proof anchored"
+          detail={
+            proof.status === 'verified'
+              ? `Confirmed on ${proof.chain}`
+              : proof.status === 'pending'
+              ? 'Waiting for block confirmation'
+              : 'Anchoring failed'
+          }
+        />
+        <ProofStep
+          num={4}
+          done={proof.status === 'verified'}
+          title="Verification result"
+          detail={
+            proof.status === 'verified'
+              ? 'Hash matches on-chain record. Report data is intact.'
+              : proof.status === 'pending'
+              ? 'Pending chain confirmation'
+              : 'Verification could not be completed.'
+          }
+        />
+      </div>
+
+      {/* Explorer link */}
+      {proof.txHash && proof.explorerBaseUrl && (
+        <a
+          href={`${proof.explorerBaseUrl}/tx/${proof.txHash}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm text-primary underline-offset-4 hover:underline"
+        >
+          View on {proof.chain} explorer →
+        </a>
+      )}
+    </div>
+  );
+}
+
+function ProofStep({
+  num, title, detail, note,
+  done = false, pending = false, failed = false,
+}: {
+  num: number; title: string; detail: string; note?: string;
+  done?: boolean; pending?: boolean; failed?: boolean;
+}) {
+  const icon = done ? '✓' : failed ? '✕' : pending ? '⋯' : String(num);
+  const cls = done
+    ? 'bg-success/15 text-success'
+    : failed
+    ? 'bg-destructive/15 text-destructive'
+    : pending
+    ? 'bg-warning/15 text-warning'
+    : 'bg-muted text-muted-foreground';
+
+  return (
+    <div className="flex gap-3 py-3">
+      <div className={`w-7 h-7 rounded-full flex items-center justify-center text-xs font-medium flex-shrink-0 ${cls}`}>
+        {icon}
+      </div>
+      <div className="min-w-0">
+        <p className="text-sm font-medium">{title}</p>
+        <p className="font-mono text-xs text-muted-foreground break-all mt-0.5">{detail}</p>
+        {note && <p className="text-xs text-muted-foreground mt-0.5">{note}</p>}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
closes #224
closes #225
closes #226
closes #227
## What was done

Implements four MVP frontend surfaces from the pilot transparency layer.

| Issue | Page | Route | Auth |
|-------|------|-------|------|
| #227 | Proof verification | `/verify` | Public |
| #226 | Public map discovery | `/map` | Public |
| #225 | Admin config | `/admin/config` | Admin |
| #224 | Admin analytics | `/admin/analytics` | Admin |

## Changes

- **Proof verify** — accepts report ID or tx hash, renders snapshot hash, status-chain steps, explorer link, and clear explanations for pending/failed/missing states
- **Public map** — bounds query with status, category, and district filters; marker detail preview; report list view; no secure media or moderation state exposed
- **Admin config** — category enable/disable toggles, moderation threshold sliders (auto-flag, auto-reject, SLA warning), safe defaults on missing config, audit log
- **Analytics** — summary metric cards, status/category/district breakdowns with bar charts, district SLA table, daily volume trend; time range selector wired to API
- **`lib/api/`** — typed fetch clients for all four backend contracts

## Before merging

- [ ] Set `NEXT_PUBLIC_API_URL` in environment
- [ ] Replace `<MapCanvas>` placeholder in `app/map/page.tsx` with MapLibre or Leaflet
- [ ] Confirm admin layout auth guard covers `/admin/*`
- [ ] Backend endpoints (S1-BE-20, S2-STL-08, S2-BE-14, S1-BE-23, S2-BE-08, S2-BE-09, S2-BE-16) are deployed or mocked