### PR TITLE
feat(auth): session store, refresh rotation, and logout endpoints

### DIFF
--- a/apps/api/src/__tests__/auth.test.ts
+++ b/apps/api/src/__tests__/auth.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import request from "supertest";
+
+import { app, sessionStore } from "../app.js";
 
 // ── password service ──────────────────────────────────────────────────────────
 import { hashPassword, verifyPassword } from "../services/password.js";
@@ -38,8 +40,53 @@ describe("account model", () => {
   });
 });
 
+// ── session store unit tests ──────────────────────────────────────────────────
+import { MemorySessionStore } from "../services/sessionStore.js";
+
+describe("MemorySessionStore", () => {
+  let store: MemorySessionStore;
+
+  beforeEach(() => {
+    store = new MemorySessionStore();
+  });
+
+  it("creates and retrieves a session by sessionId", () => {
+    const s = store.create("acc1");
+    expect(store.getBySessionId(s.sessionId)).toEqual(s);
+  });
+
+  it("retrieves a session by refreshToken", () => {
+    const s = store.create("acc1");
+    expect(store.getByRefreshToken(s.refreshToken)).toEqual(s);
+  });
+
+  it("rotate issues new tokens and invalidates old refreshToken", () => {
+    const s = store.create("acc1");
+    const rotated = store.rotate(s.sessionId);
+    expect(rotated.refreshToken).not.toBe(s.refreshToken);
+    expect(store.getByRefreshToken(s.refreshToken)).toBeUndefined();
+    expect(store.getByRefreshToken(rotated.refreshToken)).toBeDefined();
+  });
+
+  it("revoke removes the session", () => {
+    const s = store.create("acc1");
+    store.revoke(s.sessionId);
+    expect(store.getBySessionId(s.sessionId)).toBeUndefined();
+    expect(store.getByRefreshToken(s.refreshToken)).toBeUndefined();
+  });
+
+  it("revokeAll removes only sessions for the given account", () => {
+    const s1 = store.create("acc1");
+    const s2 = store.create("acc1");
+    const s3 = store.create("acc2");
+    store.revokeAll("acc1");
+    expect(store.getBySessionId(s1.sessionId)).toBeUndefined();
+    expect(store.getBySessionId(s2.sessionId)).toBeUndefined();
+    expect(store.getBySessionId(s3.sessionId)).toBeDefined();
+  });
+});
+
 // ── register endpoint ─────────────────────────────────────────────────────────
-import { app } from "../app.js";
 
 describe("POST /auth/register", () => {
   it("creates an account and returns 201", async () => {
@@ -72,13 +119,15 @@ describe("POST /auth/register", () => {
 });
 
 // ── login endpoint ────────────────────────────────────────────────────────────
+
 describe("POST /auth/login", () => {
-  it("returns token on valid credentials", async () => {
+  it("returns accessToken and refreshToken on valid credentials", async () => {
     await request(app).post("/auth/register").send({ email: "login@example.com", password: "password123" });
     const res = await request(app).post("/auth/login").send({ email: "login@example.com", password: "password123" });
 
     expect(res.status).toBe(200);
-    expect(typeof res.body.token).toBe("string");
+    expect(typeof res.body.accessToken).toBe("string");
+    expect(typeof res.body.refreshToken).toBe("string");
     expect(res.body.account.email).toBe("login@example.com");
   });
 
@@ -94,5 +143,129 @@ describe("POST /auth/login", () => {
 
     expect(res.status).toBe(401);
     expect(res.body.code).toBe("INVALID_CREDENTIALS");
+  });
+});
+
+// ── refresh endpoint ──────────────────────────────────────────────────────────
+
+describe("POST /auth/refresh", () => {
+  async function loginUser(email: string): Promise<{ accessToken: string; refreshToken: string }> {
+    await request(app).post("/auth/register").send({ email, password: "password123" });
+    const res = await request(app).post("/auth/login").send({ email, password: "password123" });
+    return res.body;
+  }
+
+  it("rotates tokens and returns new pair", async () => {
+    const { refreshToken } = await loginUser("refresh1@example.com");
+    const res = await request(app).post("/auth/refresh").send({ refreshToken });
+
+    expect(res.status).toBe(200);
+    expect(typeof res.body.accessToken).toBe("string");
+    expect(typeof res.body.refreshToken).toBe("string");
+    expect(res.body.refreshToken).not.toBe(refreshToken);
+  });
+
+  it("rejects a replayed (already-rotated) refresh token", async () => {
+    const { refreshToken } = await loginUser("refresh2@example.com");
+    await request(app).post("/auth/refresh").send({ refreshToken });
+    const res = await request(app).post("/auth/refresh").send({ refreshToken });
+
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe("INVALID_TOKEN");
+  });
+
+  it("returns 401 for an unknown refresh token", async () => {
+    const res = await request(app).post("/auth/refresh").send({ refreshToken: "bogus" });
+
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe("INVALID_TOKEN");
+  });
+});
+
+// ── single-device logout ──────────────────────────────────────────────────────
+
+describe("POST /auth/logout", () => {
+  async function loginUser(email: string): Promise<{ accessToken: string; refreshToken: string }> {
+    await request(app).post("/auth/register").send({ email, password: "password123" });
+    const res = await request(app).post("/auth/login").send({ email, password: "password123" });
+    return res.body;
+  }
+
+  it("revokes the current session and returns 200", async () => {
+    const { accessToken } = await loginUser("logout1@example.com");
+    const res = await request(app)
+      .post("/auth/logout")
+      .set("Authorization", `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe("Session revoked.");
+    expect(sessionStore.getBySessionId(accessToken)).toBeUndefined();
+  });
+
+  it("leaves other sessions intact", async () => {
+    const email = "logout2@example.com";
+    await request(app).post("/auth/register").send({ email, password: "password123" });
+    const s1 = (await request(app).post("/auth/login").send({ email, password: "password123" })).body;
+    const s2 = (await request(app).post("/auth/login").send({ email, password: "password123" })).body;
+
+    await request(app).post("/auth/logout").set("Authorization", `Bearer ${s1.accessToken}`);
+
+    expect(sessionStore.getBySessionId(s1.accessToken)).toBeUndefined();
+    expect(sessionStore.getBySessionId(s2.accessToken)).toBeDefined();
+  });
+
+  it("returns 401 without Authorization header", async () => {
+    const res = await request(app).post("/auth/logout");
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe("INVALID_TOKEN");
+  });
+
+  it("returns 404 for an already-revoked session", async () => {
+    const { accessToken } = await loginUser("logout3@example.com");
+    await request(app).post("/auth/logout").set("Authorization", `Bearer ${accessToken}`);
+    const res = await request(app).post("/auth/logout").set("Authorization", `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe("SESSION_NOT_FOUND");
+  });
+});
+
+// ── logout-all-sessions ───────────────────────────────────────────────────────
+
+describe("POST /auth/logout/all", () => {
+  it("revokes all sessions for the account", async () => {
+    const email = "logoutall@example.com";
+    await request(app).post("/auth/register").send({ email, password: "password123" });
+    const s1 = (await request(app).post("/auth/login").send({ email, password: "password123" })).body;
+    const s2 = (await request(app).post("/auth/login").send({ email, password: "password123" })).body;
+
+    const res = await request(app)
+      .post("/auth/logout/all")
+      .set("Authorization", `Bearer ${s1.accessToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe("All sessions revoked.");
+    expect(sessionStore.getBySessionId(s1.accessToken)).toBeUndefined();
+    expect(sessionStore.getBySessionId(s2.accessToken)).toBeUndefined();
+  });
+
+  it("does not affect sessions of other accounts", async () => {
+    const emailA = "logoutall-a@example.com";
+    const emailB = "logoutall-b@example.com";
+    await request(app).post("/auth/register").send({ email: emailA, password: "password123" });
+    await request(app).post("/auth/register").send({ email: emailB, password: "password123" });
+    const sA = (await request(app).post("/auth/login").send({ email: emailA, password: "password123" })).body;
+    const sB = (await request(app).post("/auth/login").send({ email: emailB, password: "password123" })).body;
+
+    await request(app).post("/auth/logout/all").set("Authorization", `Bearer ${sA.accessToken}`);
+
+    expect(sessionStore.getBySessionId(sA.accessToken)).toBeUndefined();
+    expect(sessionStore.getBySessionId(sB.accessToken)).toBeDefined();
+  });
+
+  it("returns 401 without Authorization header", async () => {
+    const res = await request(app).post("/auth/logout/all");
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe("INVALID_TOKEN");
   });
 });

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -5,10 +5,19 @@ import morgan from "morgan";
 import { z } from "zod";
 
 import { readServiceEnv } from "@sidewalk/config";
-import type { ApiHealth, AuthStatus, RegisterResponse, LoginResponse, AuthErrorResponse } from "@sidewalk/types";
+import type {
+  ApiHealth,
+  AuthStatus,
+  RegisterResponse,
+  LoginResponse,
+  RefreshResponse,
+  LogoutResponse,
+  AuthErrorResponse
+} from "@sidewalk/types";
 import type { Account } from "./models/account.js";
 import { toPublic } from "./models/account.js";
 import { hashPassword, verifyPassword } from "./services/password.js";
+import { MemorySessionStore } from "./services/sessionStore.js";
 
 const env = readServiceEnv(
   "api",
@@ -27,39 +36,54 @@ app.use(cors({ origin: env.ALLOWED_ORIGIN, credentials: true }));
 app.use(express.json());
 app.use(morgan("dev"));
 
-app.get("/health", (_request, response) => {
+// ── Shared stores ─────────────────────────────────────────────────────────────
+const accounts = new Map<string, Account>();
+let nextId = 1;
+export const sessionStore = new MemorySessionStore();
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function bearerToken(authHeader: string | undefined): string | null {
+  if (!authHeader?.startsWith("Bearer ")) return null;
+  return authHeader.slice(7);
+}
+
+// ── Health / status ───────────────────────────────────────────────────────────
+
+app.get("/health", (_req, res) => {
   const payload: ApiHealth = { service: "api", status: "ok", timestamp: new Date().toISOString() };
-  response.json(payload);
+  res.json(payload);
 });
 
-app.get("/auth/status", (_request, response) => {
+app.get("/auth/status", (_req, res) => {
   const payload: AuthStatus = {
     phase: "foundation",
     ready: false,
     nextStep: "Build signup, login, session, and recovery flows in Authentication batch 1."
   };
-  response.json(payload);
+  res.json(payload);
 });
 
-// ── In-memory account store (replaced by a DB in a later milestone) ───────────
-const accounts = new Map<string, Account>();
-let nextId = 1;
+// ── Schemas ───────────────────────────────────────────────────────────────────
 
 const registerSchema = z.object({ email: z.string().email(), password: z.string().min(8) });
 const loginSchema = z.object({ email: z.string().email(), password: z.string().min(1) });
+const refreshSchema = z.object({ refreshToken: z.string().min(1) });
 
-app.post("/auth/register", async (request, response) => {
-  const parsed = registerSchema.safeParse(request.body);
+// ── Register ──────────────────────────────────────────────────────────────────
+
+app.post("/auth/register", async (req, res) => {
+  const parsed = registerSchema.safeParse(req.body);
   if (!parsed.success) {
     const err: AuthErrorResponse = { code: "VALIDATION_ERROR", message: parsed.error.issues[0].message };
-    response.status(400).json(err);
+    res.status(400).json(err);
     return;
   }
 
   const { email, password } = parsed.data;
   if ([...accounts.values()].some((a) => a.email === email)) {
     const err: AuthErrorResponse = { code: "EMAIL_TAKEN", message: "Email already registered." };
-    response.status(409).json(err);
+    res.status(409).json(err);
     return;
   }
 
@@ -76,14 +100,16 @@ app.post("/auth/register", async (request, response) => {
 
   const pub = toPublic(account);
   const body: RegisterResponse = { id: pub.id, email: pub.email, verified: pub.verified, createdAt: pub.createdAt.toISOString() };
-  response.status(201).json(body);
+  res.status(201).json(body);
 });
 
-app.post("/auth/login", async (request, response) => {
-  const parsed = loginSchema.safeParse(request.body);
+// ── Login ─────────────────────────────────────────────────────────────────────
+
+app.post("/auth/login", async (req, res) => {
+  const parsed = loginSchema.safeParse(req.body);
   if (!parsed.success) {
     const err: AuthErrorResponse = { code: "VALIDATION_ERROR", message: parsed.error.issues[0].message };
-    response.status(400).json(err);
+    res.status(400).json(err);
     return;
   }
 
@@ -91,13 +117,83 @@ app.post("/auth/login", async (request, response) => {
   const account = [...accounts.values()].find((a) => a.email === email);
   if (!account || !(await verifyPassword(password, account.passwordHash))) {
     const err: AuthErrorResponse = { code: "INVALID_CREDENTIALS", message: "Invalid email or password." };
-    response.status(401).json(err);
+    res.status(401).json(err);
     return;
   }
 
-  const token = Buffer.from(JSON.stringify({ sub: account.id, iat: Date.now() })).toString("base64url");
-  const body: LoginResponse = { token, account: { id: account.id, email: account.email, verified: account.verified } };
-  response.status(200).json(body);
+  const session = sessionStore.create(account.id);
+  const body: LoginResponse = {
+    accessToken: session.sessionId,
+    refreshToken: session.refreshToken,
+    account: { id: account.id, email: account.email, verified: account.verified }
+  };
+  res.status(200).json(body);
+});
+
+// ── Refresh ───────────────────────────────────────────────────────────────────
+
+app.post("/auth/refresh", (req, res) => {
+  const parsed = refreshSchema.safeParse(req.body);
+  if (!parsed.success) {
+    const err: AuthErrorResponse = { code: "VALIDATION_ERROR", message: parsed.error.issues[0].message };
+    res.status(400).json(err);
+    return;
+  }
+
+  const existing = sessionStore.getByRefreshToken(parsed.data.refreshToken);
+  if (!existing) {
+    const err: AuthErrorResponse = { code: "INVALID_TOKEN", message: "Refresh token is invalid or already used." };
+    res.status(401).json(err);
+    return;
+  }
+
+  const rotated = sessionStore.rotate(existing.sessionId);
+  const body: RefreshResponse = { accessToken: rotated.sessionId, refreshToken: rotated.refreshToken };
+  res.status(200).json(body);
+});
+
+// ── Logout (single device) ────────────────────────────────────────────────────
+
+app.post("/auth/logout", (req, res) => {
+  const token = bearerToken(req.headers.authorization);
+  if (!token) {
+    const err: AuthErrorResponse = { code: "INVALID_TOKEN", message: "Missing or malformed Authorization header." };
+    res.status(401).json(err);
+    return;
+  }
+
+  const session = sessionStore.getBySessionId(token);
+  if (!session) {
+    const err: AuthErrorResponse = { code: "SESSION_NOT_FOUND", message: "Session not found or already revoked." };
+    res.status(404).json(err);
+    return;
+  }
+
+  sessionStore.revoke(session.sessionId);
+  const body: LogoutResponse = { message: "Session revoked." };
+  res.status(200).json(body);
+});
+
+// ── Logout all sessions ───────────────────────────────────────────────────────
+
+app.post("/auth/logout/all", (req, res) => {
+  const token = bearerToken(req.headers.authorization);
+  if (!token) {
+    const err: AuthErrorResponse = { code: "INVALID_TOKEN", message: "Missing or malformed Authorization header." };
+    res.status(401).json(err);
+    return;
+  }
+
+  const session = sessionStore.getBySessionId(token);
+  if (!session) {
+    const err: AuthErrorResponse = { code: "SESSION_NOT_FOUND", message: "Session not found or already revoked." };
+    res.status(404).json(err);
+    return;
+  }
+
+  sessionStore.revokeAll(session.accountId);
+  const body: LogoutResponse = { message: "All sessions revoked." };
+  res.status(200).json(body);
 });
 
 export { env };

--- a/apps/api/src/services/sessionStore.ts
+++ b/apps/api/src/services/sessionStore.ts
@@ -1,0 +1,93 @@
+/**
+ * Session store abstraction — issue, lookup, rotate, and revoke auth sessions.
+ *
+ * The in-memory implementation is suitable for local development and tests.
+ * Swap it for a Redis or DB-backed implementation before production.
+ */
+
+export type Session = {
+  sessionId: string;
+  accountId: string;
+  refreshToken: string;
+  createdAt: Date;
+};
+
+export interface SessionStore {
+  /** Persist a new session and return it. */
+  create(accountId: string): Session;
+  /** Look up a session by its sessionId (access token). Returns undefined if not found. */
+  getBySessionId(sessionId: string): Session | undefined;
+  /** Look up a session by its refreshToken. Returns undefined if not found or already rotated. */
+  getByRefreshToken(refreshToken: string): Session | undefined;
+  /** Rotate the refresh token for a session; invalidates the old refreshToken. */
+  rotate(sessionId: string): Session;
+  /** Revoke a single session. */
+  revoke(sessionId: string): void;
+  /** Revoke all sessions for an account. */
+  revokeAll(accountId: string): void;
+}
+
+// ── In-memory implementation ──────────────────────────────────────────────────
+
+import { randomBytes } from "node:crypto";
+
+function newToken(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+export class MemorySessionStore implements SessionStore {
+  private readonly sessions = new Map<string, Session>();
+  /** refreshToken → sessionId index for O(1) lookup */
+  private readonly byRefresh = new Map<string, string>();
+
+  create(accountId: string): Session {
+    const session: Session = {
+      sessionId: newToken(),
+      accountId,
+      refreshToken: newToken(),
+      createdAt: new Date()
+    };
+    this.sessions.set(session.sessionId, session);
+    this.byRefresh.set(session.refreshToken, session.sessionId);
+    return session;
+  }
+
+  getBySessionId(sessionId: string): Session | undefined {
+    return this.sessions.get(sessionId);
+  }
+
+  getByRefreshToken(refreshToken: string): Session | undefined {
+    const sessionId = this.byRefresh.get(refreshToken);
+    return sessionId ? this.sessions.get(sessionId) : undefined;
+  }
+
+  rotate(sessionId: string): Session {
+    const existing = this.sessions.get(sessionId);
+    if (!existing) throw new Error("Session not found");
+
+    // Invalidate old refresh token
+    this.byRefresh.delete(existing.refreshToken);
+
+    const updated: Session = { ...existing, refreshToken: newToken() };
+    this.sessions.set(sessionId, updated);
+    this.byRefresh.set(updated.refreshToken, sessionId);
+    return updated;
+  }
+
+  revoke(sessionId: string): void {
+    const session = this.sessions.get(sessionId);
+    if (session) {
+      this.byRefresh.delete(session.refreshToken);
+      this.sessions.delete(sessionId);
+    }
+  }
+
+  revokeAll(accountId: string): void {
+    for (const [sessionId, session] of this.sessions) {
+      if (session.accountId === accountId) {
+        this.byRefresh.delete(session.refreshToken);
+        this.sessions.delete(sessionId);
+      }
+    }
+  }
+}

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -19,13 +19,17 @@ export type LoginRequest = {
   password: string;
 };
 
-/**
- * Minimal session data returned on successful login.
- * Transport-agnostic: the token field carries a JWT for bearer flows;
- * cookie-backed sessions can ignore it and rely on Set-Cookie instead.
- */
-export type LoginResponse = {
-  token: string;
+// ── Session tokens ────────────────────────────────────────────────────────────
+
+/** Opaque token pair returned on login and refresh. */
+export type SessionTokens = {
+  /** Opaque access token (base64url-encoded session id). */
+  accessToken: string;
+  /** Opaque refresh token used to rotate the session. */
+  refreshToken: string;
+};
+
+export type LoginResponse = SessionTokens & {
   account: {
     id: string;
     email: string;
@@ -33,13 +37,24 @@ export type LoginResponse = {
   };
 };
 
+// ── Refresh ───────────────────────────────────────────────────────────────────
+
+export type RefreshRequest = { refreshToken: string };
+export type RefreshResponse = SessionTokens;
+
+// ── Logout ────────────────────────────────────────────────────────────────────
+
+export type LogoutResponse = { message: string };
+
 // ── Shared error shape ────────────────────────────────────────────────────────
 
 export type AuthErrorCode =
   | "VALIDATION_ERROR"
   | "EMAIL_TAKEN"
   | "INVALID_CREDENTIALS"
-  | "ACCOUNT_UNVERIFIED";
+  | "ACCOUNT_UNVERIFIED"
+  | "INVALID_TOKEN"
+  | "SESSION_NOT_FOUND";
 
 export type AuthErrorResponse = {
   code: AuthErrorCode;


### PR DESCRIPTION
Implements the session persistence layer and all session-lifecycle endpoints needed for the Authentication milestone.

**What's in this PR**

- `MemorySessionStore` — a `SessionStore` interface with in-memory implementation (create, rotate, revoke, revokeAll). Designed to be swapped for a persistent backing store later.
- Login now returns `accessToken` + `refreshToken` instead of a bare token.
- `POST /auth/refresh` — rotates the session; replayed refresh tokens are rejected with 401.
- `POST /auth/logout` — revokes the caller's current session only; other sessions remain valid.
- `POST /auth/logout/all` — revokes every active session for the account (compromised-account recovery).
- New shared types: `SessionTokens`, `RefreshRequest/Response`, `LogoutResponse`, error codes `INVALID_TOKEN` / `SESSION_NOT_FOUND`.
- 24 tests covering all new behavior; typecheck passes across all 6 packages.

Closes #321, Closes #322, Closes #323, Closes #324