### PR TITLE
feat(auth): email verification, password reset, and rate limiting

### DIFF
--- a/apps/api/src/__tests__/auth.test.ts
+++ b/apps/api/src/__tests__/auth.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import request from "supertest";
 
-import { app, sessionStore } from "../app.js";
+import { app, sessionStore, tokenStore } from "../app.js";
 
 // ── password service ──────────────────────────────────────────────────────────
 import { hashPassword, verifyPassword } from "../services/password.js";
@@ -267,5 +267,161 @@ describe("POST /auth/logout/all", () => {
     const res = await request(app).post("/auth/logout/all");
     expect(res.status).toBe(401);
     expect(res.body.code).toBe("INVALID_TOKEN");
+  });
+});
+
+// ── email verification ────────────────────────────────────────────────────────
+
+describe("POST /auth/verify-email", () => {
+  it("marks account verified with a valid token", async () => {
+    const regRes = await request(app).post("/auth/register").send({ email: "verify2@example.com", password: "password123" });
+    const vToken = tokenStore.issue(regRes.body.id, "verify");
+
+    const res = await request(app).post("/auth/verify-email").send({ token: vToken });
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe("Email verified.");
+  });
+
+  it("rejects an invalid token", async () => {
+    const res = await request(app).post("/auth/verify-email").send({ token: "bogus" });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("INVALID_TOKEN");
+  });
+
+  it("rejects a replayed token", async () => {
+    const regRes = await request(app).post("/auth/register").send({ email: "verify3@example.com", password: "password123" });
+    const vToken = tokenStore.issue(regRes.body.id, "verify");
+    await request(app).post("/auth/verify-email").send({ token: vToken });
+    const res = await request(app).post("/auth/verify-email").send({ token: vToken });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("INVALID_TOKEN");
+  });
+});
+
+// ── password reset request ────────────────────────────────────────────────────
+
+describe("POST /auth/password-reset/request", () => {
+  it("returns privacy-safe response for a known email", async () => {
+    await request(app).post("/auth/register").send({ email: "reset1@example.com", password: "password123" });
+    const res = await request(app).post("/auth/password-reset/request").send({ email: "reset1@example.com" });
+    expect(res.status).toBe(200);
+    expect(res.body.message).toMatch(/reset link/i);
+  });
+
+  it("returns the same response for an unknown email", async () => {
+    const res = await request(app).post("/auth/password-reset/request").send({ email: "ghost@example.com" });
+    expect(res.status).toBe(200);
+    expect(res.body.message).toMatch(/reset link/i);
+  });
+
+  it("returns 400 for invalid email", async () => {
+    const res = await request(app).post("/auth/password-reset/request").send({ email: "not-an-email" });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("VALIDATION_ERROR");
+  });
+});
+
+// ── password reset completion ─────────────────────────────────────────────────
+
+describe("POST /auth/password-reset/complete", () => {
+  async function setupReset(email: string): Promise<{ accountId: string; resetToken: string }> {
+    const regRes = await request(app).post("/auth/register").send({ email, password: "oldpass123" });
+    const accountId = regRes.body.id;
+    const resetToken = tokenStore.issue(accountId, "reset");
+    return { accountId, resetToken };
+  }
+
+  it("updates password and revokes sessions on success", async () => {
+    const email = "complete1@example.com";
+    const { accountId, resetToken } = await setupReset(email);
+    const loginRes = await request(app).post("/auth/login").send({ email, password: "oldpass123" });
+    const { accessToken } = loginRes.body;
+
+    const res = await request(app).post("/auth/password-reset/complete").send({ token: resetToken, password: "newpass456" });
+    expect(res.status).toBe(200);
+    expect(res.body.message).toMatch(/log in again/i);
+
+    // Old session should be revoked
+    expect(sessionStore.getBySessionId(accessToken)).toBeUndefined();
+
+    // New password should work
+    const newLogin = await request(app).post("/auth/login").send({ email, password: "newpass456" });
+    expect(newLogin.status).toBe(200);
+  });
+
+  it("rejects an invalid token", async () => {
+    const res = await request(app).post("/auth/password-reset/complete").send({ token: "bogus", password: "newpass456" });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("INVALID_TOKEN");
+  });
+
+  it("rejects a replayed token", async () => {
+    const { resetToken } = await setupReset("complete2@example.com");
+    await request(app).post("/auth/password-reset/complete").send({ token: resetToken, password: "newpass456" });
+    const res = await request(app).post("/auth/password-reset/complete").send({ token: resetToken, password: "anotherpass" });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("INVALID_TOKEN");
+  });
+
+  it("rejects a verify token used on the reset endpoint", async () => {
+    const regRes = await request(app).post("/auth/register").send({ email: "complete3@example.com", password: "password123" });
+    const wrongToken = tokenStore.issue(regRes.body.id, "verify");
+    const res = await request(app).post("/auth/password-reset/complete").send({ token: wrongToken, password: "newpass456" });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("INVALID_TOKEN");
+  });
+});
+
+// ── rate limiting ─────────────────────────────────────────────────────────────
+
+import { makeRateLimiter } from "../middleware/authRateLimit.js";
+import type { Request, Response } from "express";
+
+describe("auth rate limiting", () => {
+  function makeReq(ip = "1.2.3.4"): Request {
+    return { ip } as unknown as Request;
+  }
+
+  function makeRes() {
+    const res = { statusCode: 200, body: undefined as unknown } as {
+      statusCode: number;
+      body: unknown;
+      status: (n: number) => { json: (b: unknown) => void };
+    };
+    res.status = (n: number) => {
+      res.statusCode = n;
+      return { json: (b: unknown) => { res.body = b; } };
+    };
+    return res;
+  }
+
+  it("allows requests under the limit", () => {
+    const limiter = makeRateLimiter(3, 60_000);
+    for (let i = 0; i < 3; i++) {
+      let passed = false;
+      limiter(makeReq(), makeRes() as unknown as Response, () => { passed = true; });
+      expect(passed).toBe(true);
+    }
+  });
+
+  it("blocks requests over the limit", () => {
+    const limiter = makeRateLimiter(3, 60_000);
+    for (let i = 0; i < 3; i++) {
+      limiter(makeReq(), makeRes() as unknown as Response, () => {});
+    }
+    const res = makeRes();
+    limiter(makeReq(), res as unknown as Response, () => {});
+    expect(res.statusCode).toBe(429);
+    expect((res.body as any).code).toBe("RATE_LIMITED");
+  });
+
+  it("tracks different IPs independently", () => {
+    const limiter = makeRateLimiter(2, 60_000);
+    limiter(makeReq("10.0.0.1"), makeRes() as unknown as Response, () => {});
+    limiter(makeReq("10.0.0.1"), makeRes() as unknown as Response, () => {});
+    // 10.0.0.1 is now at limit; 10.0.0.2 should still pass
+    let passed = false;
+    limiter(makeReq("10.0.0.2"), makeRes() as unknown as Response, () => { passed = true; });
+    expect(passed).toBe(true);
   });
 });

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -12,12 +12,22 @@ import type {
   LoginResponse,
   RefreshResponse,
   LogoutResponse,
-  AuthErrorResponse
+  AuthErrorResponse,
+  VerifyEmailResponse,
+  PasswordResetRequestResponse,
+  PasswordResetCompleteResponse
 } from "@sidewalk/types";
 import type { Account } from "./models/account.js";
 import { toPublic } from "./models/account.js";
 import { hashPassword, verifyPassword } from "./services/password.js";
 import { MemorySessionStore } from "./services/sessionStore.js";
+import { MemoryTokenStore } from "./services/tokenStore.js";
+import {
+  loginRateLimit,
+  registerRateLimit,
+  resetRateLimit,
+  verifyResendRateLimit
+} from "./middleware/authRateLimit.js";
 
 const env = readServiceEnv(
   "api",
@@ -40,6 +50,7 @@ app.use(morgan("dev"));
 const accounts = new Map<string, Account>();
 let nextId = 1;
 export const sessionStore = new MemorySessionStore();
+export const tokenStore = new MemoryTokenStore();
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -69,10 +80,13 @@ app.get("/auth/status", (_req, res) => {
 const registerSchema = z.object({ email: z.string().email(), password: z.string().min(8) });
 const loginSchema = z.object({ email: z.string().email(), password: z.string().min(1) });
 const refreshSchema = z.object({ refreshToken: z.string().min(1) });
+const verifyEmailSchema = z.object({ token: z.string().min(1) });
+const resetRequestSchema = z.object({ email: z.string().email() });
+const resetCompleteSchema = z.object({ token: z.string().min(1), password: z.string().min(8) });
 
 // ── Register ──────────────────────────────────────────────────────────────────
 
-app.post("/auth/register", async (req, res) => {
+app.post("/auth/register", registerRateLimit, async (req, res) => {
   const parsed = registerSchema.safeParse(req.body);
   if (!parsed.success) {
     const err: AuthErrorResponse = { code: "VALIDATION_ERROR", message: parsed.error.issues[0].message };
@@ -98,14 +112,50 @@ app.post("/auth/register", async (req, res) => {
   };
   accounts.set(account.id, account);
 
+  // Issue verification token (log for local dev; swap for email transport in production)
+  const verifyToken = tokenStore.issue(account.id, "verify");
+  if (env.APP_ENV !== "test") {
+    console.log(`[dev] verify token for ${email}: ${verifyToken}`);
+  }
+
   const pub = toPublic(account);
   const body: RegisterResponse = { id: pub.id, email: pub.email, verified: pub.verified, createdAt: pub.createdAt.toISOString() };
   res.status(201).json(body);
 });
 
+// ── Email verification ────────────────────────────────────────────────────────
+
+app.post("/auth/verify-email", verifyResendRateLimit, (req, res) => {
+  const parsed = verifyEmailSchema.safeParse(req.body);
+  if (!parsed.success) {
+    const err: AuthErrorResponse = { code: "VALIDATION_ERROR", message: parsed.error.issues[0].message };
+    res.status(400).json(err);
+    return;
+  }
+
+  const accountId = tokenStore.consume(parsed.data.token, "verify");
+  if (!accountId) {
+    const err: AuthErrorResponse = { code: "INVALID_TOKEN", message: "Verification token is invalid or expired." };
+    res.status(400).json(err);
+    return;
+  }
+
+  const account = accounts.get(accountId);
+  if (!account) {
+    const err: AuthErrorResponse = { code: "INVALID_TOKEN", message: "Verification token is invalid or expired." };
+    res.status(400).json(err);
+    return;
+  }
+
+  account.verified = true;
+  account.updatedAt = new Date();
+  const body: VerifyEmailResponse = { message: "Email verified." };
+  res.status(200).json(body);
+});
+
 // ── Login ─────────────────────────────────────────────────────────────────────
 
-app.post("/auth/login", async (req, res) => {
+app.post("/auth/login", loginRateLimit, async (req, res) => {
   const parsed = loginSchema.safeParse(req.body);
   if (!parsed.success) {
     const err: AuthErrorResponse = { code: "VALIDATION_ERROR", message: parsed.error.issues[0].message };
@@ -149,6 +199,65 @@ app.post("/auth/refresh", (req, res) => {
 
   const rotated = sessionStore.rotate(existing.sessionId);
   const body: RefreshResponse = { accessToken: rotated.sessionId, refreshToken: rotated.refreshToken };
+  res.status(200).json(body);
+});
+
+// ── Password reset — request ──────────────────────────────────────────────────
+
+// Always returns the same shape to prevent account enumeration.
+app.post("/auth/password-reset/request", resetRateLimit, (req, res) => {
+  const parsed = resetRequestSchema.safeParse(req.body);
+  if (!parsed.success) {
+    const err: AuthErrorResponse = { code: "VALIDATION_ERROR", message: parsed.error.issues[0].message };
+    res.status(400).json(err);
+    return;
+  }
+
+  const account = [...accounts.values()].find((a) => a.email === parsed.data.email);
+  if (account) {
+    const resetToken = tokenStore.issue(account.id, "reset");
+    if (env.APP_ENV !== "test") {
+      console.log(`[dev] reset token for ${account.email}: ${resetToken}`);
+    }
+  }
+
+  const body: PasswordResetRequestResponse = {
+    message: "If that email is registered you will receive a reset link shortly."
+  };
+  res.status(200).json(body);
+});
+
+// ── Password reset — completion ───────────────────────────────────────────────
+
+app.post("/auth/password-reset/complete", resetRateLimit, async (req, res) => {
+  const parsed = resetCompleteSchema.safeParse(req.body);
+  if (!parsed.success) {
+    const err: AuthErrorResponse = { code: "VALIDATION_ERROR", message: parsed.error.issues[0].message };
+    res.status(400).json(err);
+    return;
+  }
+
+  const accountId = tokenStore.consume(parsed.data.token, "reset");
+  if (!accountId) {
+    const err: AuthErrorResponse = { code: "INVALID_TOKEN", message: "Reset token is invalid or expired." };
+    res.status(400).json(err);
+    return;
+  }
+
+  const account = accounts.get(accountId);
+  if (!account) {
+    const err: AuthErrorResponse = { code: "INVALID_TOKEN", message: "Reset token is invalid or expired." };
+    res.status(400).json(err);
+    return;
+  }
+
+  account.passwordHash = await hashPassword(parsed.data.password);
+  account.updatedAt = new Date();
+
+  // Revoke all sessions so stale credentials cannot be replayed.
+  sessionStore.revokeAll(accountId);
+
+  const body: PasswordResetCompleteResponse = { message: "Password updated. Please log in again." };
   res.status(200).json(body);
 });
 

--- a/apps/api/src/middleware/authRateLimit.ts
+++ b/apps/api/src/middleware/authRateLimit.ts
@@ -1,0 +1,51 @@
+/**
+ * Auth-specific rate limiting — in-memory, no external dependencies.
+ *
+ * Different auth flows get different thresholds:
+ *   login / register  → 10 req / 15 min
+ *   password reset    → 5  req / 15 min
+ *   verify resend     → 5  req / 15 min
+ *
+ * In the test environment the app-level limiters are no-ops to prevent
+ * cross-test interference. Rate-limit behaviour is verified separately
+ * using makeRateLimiter with a fresh instance.
+ */
+
+import type { Request, Response, NextFunction } from "express";
+import type { AuthErrorResponse } from "@sidewalk/types";
+
+type Bucket = { count: number; resetAt: number };
+
+export function makeRateLimiter(max: number, windowMs: number) {
+  const buckets = new Map<string, Bucket>();
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const key = req.ip ?? "unknown";
+    const now = Date.now();
+    const bucket = buckets.get(key);
+
+    if (!bucket || now > bucket.resetAt) {
+      buckets.set(key, { count: 1, resetAt: now + windowMs });
+      next();
+      return;
+    }
+
+    if (bucket.count >= max) {
+      const err: AuthErrorResponse = { code: "RATE_LIMITED", message: "Too many requests. Please try again later." };
+      res.status(429).json(err);
+      return;
+    }
+
+    bucket.count++;
+    next();
+  };
+}
+
+const WINDOW = 15 * 60 * 1000; // 15 minutes
+const IS_TEST = process.env.APP_ENV === "test";
+const passThrough = (_req: Request, _res: Response, next: NextFunction) => next();
+
+export const loginRateLimit = IS_TEST ? passThrough : makeRateLimiter(10, WINDOW);
+export const registerRateLimit = IS_TEST ? passThrough : makeRateLimiter(10, WINDOW);
+export const resetRateLimit = IS_TEST ? passThrough : makeRateLimiter(5, WINDOW);
+export const verifyResendRateLimit = IS_TEST ? passThrough : makeRateLimiter(5, WINDOW);

--- a/apps/api/src/services/tokenStore.ts
+++ b/apps/api/src/services/tokenStore.ts
@@ -1,0 +1,35 @@
+/**
+ * In-memory store for short-lived single-use tokens (email verification, password reset).
+ * Each token expires after TTL_MS and is consumed on first use.
+ */
+
+import { randomBytes } from "node:crypto";
+
+export type TokenKind = "verify" | "reset";
+
+type TokenRecord = {
+  accountId: string;
+  kind: TokenKind;
+  expiresAt: Date;
+};
+
+const TTL_MS = 60 * 60 * 1000; // 1 hour
+
+export class MemoryTokenStore {
+  private readonly tokens = new Map<string, TokenRecord>();
+
+  issue(accountId: string, kind: TokenKind): string {
+    const token = randomBytes(32).toString("base64url");
+    this.tokens.set(token, { accountId, kind, expiresAt: new Date(Date.now() + TTL_MS) });
+    return token;
+  }
+
+  /** Consume a token — returns accountId on success, null if invalid/expired. */
+  consume(token: string, kind: TokenKind): string | null {
+    const record = this.tokens.get(token);
+    if (!record || record.kind !== kind) return null;
+    this.tokens.delete(token);
+    if (record.expiresAt < new Date()) return null;
+    return record.accountId;
+  }
+}

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -3,6 +3,9 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
-    globals: false
+    globals: false,
+    env: {
+      APP_ENV: "test"
+    }
   }
 });

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -48,13 +48,30 @@ export type LogoutResponse = { message: string };
 
 // ── Shared error shape ────────────────────────────────────────────────────────
 
+// ── Email verification ────────────────────────────────────────────────────────
+
+export type VerifyEmailRequest = { token: string };
+export type VerifyEmailResponse = { message: string };
+
+// ── Password reset ────────────────────────────────────────────────────────────
+
+export type PasswordResetRequestRequest = { email: string };
+export type PasswordResetRequestResponse = { message: string };
+
+export type PasswordResetCompleteRequest = { token: string; password: string };
+export type PasswordResetCompleteResponse = { message: string };
+
+// ── Shared error shape ────────────────────────────────────────────────────────
+
 export type AuthErrorCode =
   | "VALIDATION_ERROR"
   | "EMAIL_TAKEN"
   | "INVALID_CREDENTIALS"
   | "ACCOUNT_UNVERIFIED"
   | "INVALID_TOKEN"
-  | "SESSION_NOT_FOUND";
+  | "SESSION_NOT_FOUND"
+  | "TOKEN_EXPIRED"
+  | "RATE_LIMITED";
 
 export type AuthErrorResponse = {
   code: AuthErrorCode;


### PR DESCRIPTION
Implements the four Authentication milestone issues as a single cohesive batch.

**What's in this PR**

- **#325 — Email verification tokens**: `MemoryTokenStore` issues single-use, 1-hour expiring tokens keyed by kind (`verify` / `reset`). `POST /auth/verify-email` consumes a token and flips `account.verified`.
- **#326 — Password-reset request**: `POST /auth/password-reset/request` always returns the same neutral message regardless of whether the email exists, preventing account enumeration. Tokens are only created for known accounts; local-dev delivery is logged to stdout.
- **#327 — Password-reset completion**: `POST /auth/password-reset/complete` validates the token, replaces the password hash, and immediately revokes all active sessions to eliminate replay risk.
- **#328 — Auth-specific rate limiting**: `makeRateLimiter` factory wires per-route in-memory buckets — 10 req/15 min for login and register, 5 req/15 min for reset and verify-resend. Clients receive a stable `{ code: "RATE_LIMITED" }` shape on 429.

**Tests**: 37 passing, typecheck clean. Rate-limit logic is unit-tested directly via `makeRateLimiter`; app-level limiters are bypassed in the test environment to prevent cross-test interference.

Closes #325, Closes #326, Closes #327, Closes #328