### PR TITLE
feat(web): authentication screens for signup, password reset, and session expiry

### DIFF
--- a/apps/web/app/forgot-password/page.tsx
+++ b/apps/web/app/forgot-password/page.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useState, type ReactElement, type FormEvent } from "react";
+import type {
+  PasswordResetRequestRequest,
+  PasswordResetRequestResponse,
+  AuthErrorResponse,
+} from "@sidewalk/types";
+
+type State = "idle" | "loading" | "done" | "error";
+
+export default function ForgotPasswordPage(): ReactElement {
+  const [state, setState] = useState<State>("idle");
+  const [errorMsg, setErrorMsg] = useState("");
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setState("loading");
+    const email = (e.currentTarget.elements.namedItem("email") as HTMLInputElement).value;
+    const body: PasswordResetRequestRequest = { email };
+
+    try {
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/auth/password-reset/request`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        }
+      );
+
+      if (!res.ok) {
+        const err: AuthErrorResponse = await res.json();
+        setErrorMsg(err.message);
+        setState("error");
+        return;
+      }
+
+      const _data: PasswordResetRequestResponse = await res.json();
+      setState("done");
+    } catch {
+      setErrorMsg("Something went wrong. Please try again.");
+      setState("error");
+    }
+  }
+
+  if (state === "done") {
+    return (
+      <main className="page-shell">
+        <div className="auth-card">
+          <p className="eyebrow">Request sent</p>
+          <h1 className="auth-heading">Check your inbox</h1>
+          <p className="auth-body">
+            If that address is registered, a reset link is on its way. Check
+            your spam folder if it doesn&apos;t arrive within a few minutes.
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="page-shell">
+      <div className="auth-card">
+        <p className="eyebrow">Account recovery</p>
+        <h1 className="auth-heading">Reset your password</h1>
+        <p className="auth-body">
+          Enter your email and we&apos;ll send a reset link. We won&apos;t
+          confirm whether the address is registered.
+        </p>
+
+        <form onSubmit={handleSubmit} className="auth-form" noValidate>
+          <label className="auth-label" htmlFor="email">
+            Email address
+          </label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            required
+            autoComplete="email"
+            className="auth-input"
+            disabled={state === "loading"}
+          />
+
+          {state === "error" && (
+            <p className="auth-error" role="alert">
+              {errorMsg}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            className="auth-button"
+            disabled={state === "loading"}
+          >
+            {state === "loading" ? "Sending…" : "Send reset link"}
+          </button>
+        </form>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -128,3 +128,113 @@ body {
     padding: 56px 18px 80px;
   }
 }
+
+/* ── Auth screens ─────────────────────────────────────────────────────────── */
+
+.auth-card {
+  max-width: 480px;
+  margin: 0 auto;
+  padding: 40px;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--surface);
+  backdrop-filter: blur(12px);
+  box-shadow: var(--shadow);
+}
+
+.auth-heading {
+  margin: 0 0 12px;
+  font-family: "Space Grotesk", "Avenir Next", sans-serif;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  line-height: 1.1;
+}
+
+.auth-body {
+  margin: 0 0 16px;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.auth-hint {
+  margin: 16px 0 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.auth-link {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.auth-link:hover {
+  text-decoration: underline;
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.auth-label {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.auth-input {
+  padding: 10px 14px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: rgba(255, 251, 245, 0.6);
+  color: var(--text);
+  font-size: 1rem;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.auth-input:focus {
+  border-color: var(--accent);
+}
+
+.auth-input:disabled {
+  opacity: 0.5;
+}
+
+.auth-error {
+  margin: 0;
+  padding: 10px 14px;
+  border-radius: 10px;
+  background: rgba(177, 92, 43, 0.1);
+  color: var(--accent-strong);
+  font-size: 0.9rem;
+}
+
+.auth-button {
+  padding: 12px 20px;
+  border: none;
+  border-radius: 12px;
+  background: var(--accent);
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.auth-button:hover:not(:disabled) {
+  background: var(--accent-strong);
+}
+
+.auth-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.auth-button--inline {
+  display: inline-block;
+  margin-top: 20px;
+  text-decoration: none;
+}

--- a/apps/web/app/reset-password/page.tsx
+++ b/apps/web/app/reset-password/page.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useState, type ReactElement, type FormEvent } from "react";
+import { useSearchParams } from "next/navigation";
+import type {
+  PasswordResetCompleteRequest,
+  PasswordResetCompleteResponse,
+  AuthErrorResponse,
+} from "@sidewalk/types";
+
+type State = "idle" | "loading" | "done" | "invalid" | "error";
+
+export default function ResetPasswordPage(): ReactElement {
+  const params = useSearchParams();
+  const token = params.get("token") ?? "";
+  const [state, setState] = useState<State>(token ? "idle" : "invalid");
+  const [errorMsg, setErrorMsg] = useState("");
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const els = e.currentTarget.elements;
+    const password = (els.namedItem("password") as HTMLInputElement).value;
+    const confirm = (els.namedItem("confirm") as HTMLInputElement).value;
+
+    if (password !== confirm) {
+      setErrorMsg("Passwords do not match.");
+      setState("error");
+      return;
+    }
+
+    setState("loading");
+    const body: PasswordResetCompleteRequest = { token, password };
+
+    try {
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/auth/password-reset/complete`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        }
+      );
+
+      if (!res.ok) {
+        const err: AuthErrorResponse = await res.json();
+        if (err.code === "INVALID_TOKEN" || err.code === "TOKEN_EXPIRED") {
+          setState("invalid");
+        } else {
+          setErrorMsg(err.message);
+          setState("error");
+        }
+        return;
+      }
+
+      const _data: PasswordResetCompleteResponse = await res.json();
+      setState("done");
+    } catch {
+      setErrorMsg("Something went wrong. Please try again.");
+      setState("error");
+    }
+  }
+
+  if (state === "done") {
+    return (
+      <main className="page-shell">
+        <div className="auth-card">
+          <p className="eyebrow">All set</p>
+          <h1 className="auth-heading">Password updated</h1>
+          <p className="auth-body">
+            Your password has been changed. You can now sign in with your new
+            credentials.
+          </p>
+          <a href="/login" className="auth-button auth-button--inline">
+            Go to sign in
+          </a>
+        </div>
+      </main>
+    );
+  }
+
+  if (state === "invalid") {
+    return (
+      <main className="page-shell">
+        <div className="auth-card">
+          <p className="eyebrow">Link problem</p>
+          <h1 className="auth-heading">This link is no longer valid</h1>
+          <p className="auth-body">
+            Reset links expire after 1 hour and can only be used once. Request
+            a new one to continue.
+          </p>
+          <a href="/forgot-password" className="auth-button auth-button--inline">
+            Request a new link
+          </a>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="page-shell">
+      <div className="auth-card">
+        <p className="eyebrow">Account recovery</p>
+        <h1 className="auth-heading">Choose a new password</h1>
+
+        <form onSubmit={handleSubmit} className="auth-form" noValidate>
+          <label className="auth-label" htmlFor="password">
+            New password
+          </label>
+          <input
+            id="password"
+            name="password"
+            type="password"
+            required
+            minLength={8}
+            autoComplete="new-password"
+            className="auth-input"
+            disabled={state === "loading"}
+          />
+
+          <label className="auth-label" htmlFor="confirm">
+            Confirm password
+          </label>
+          <input
+            id="confirm"
+            name="confirm"
+            type="password"
+            required
+            autoComplete="new-password"
+            className="auth-input"
+            disabled={state === "loading"}
+          />
+
+          {state === "error" && (
+            <p className="auth-error" role="alert">
+              {errorMsg}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            className="auth-button"
+            disabled={state === "loading"}
+          >
+            {state === "loading" ? "Saving…" : "Set new password"}
+          </button>
+        </form>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/session-expired/page.tsx
+++ b/apps/web/app/session-expired/page.tsx
@@ -1,0 +1,20 @@
+import type { ReactElement } from "react";
+
+export default function SessionExpiredPage(): ReactElement {
+  return (
+    <main className="page-shell">
+      <div className="auth-card">
+        <p className="eyebrow">Session ended</p>
+        <h1 className="auth-heading">You&apos;ve been signed out</h1>
+        <p className="auth-body">
+          Your session expired or was ended on another device. Sign in again to
+          continue where you left off.
+        </p>
+        {/* next param is appended by middleware so the user returns to their intended page */}
+        <a href="/login" className="auth-button auth-button--inline">
+          Sign in
+        </a>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/verify-email/page.tsx
+++ b/apps/web/app/verify-email/page.tsx
@@ -1,0 +1,27 @@
+import type { ReactElement } from "react";
+import Link from "next/link";
+
+export default function VerifyEmailPage(): ReactElement {
+  return (
+    <main className="page-shell">
+      <div className="auth-card">
+        <p className="eyebrow">Almost there</p>
+        <h1 className="auth-heading">Check your inbox</h1>
+        <p className="auth-body">
+          We sent a verification link to your email address. Click it to
+          activate your account. The link expires in 24 hours.
+        </p>
+        <p className="auth-body">
+          Didn&apos;t receive it? Check your spam folder. Resend will be
+          available once the API supports it.
+        </p>
+        <p className="auth-hint">
+          Already verified?{" "}
+          <Link href="/login" className="auth-link">
+            Sign in
+          </Link>
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/lib/authClient.ts
+++ b/apps/web/lib/authClient.ts
@@ -1,0 +1,73 @@
+/**
+ * Thin auth client for the web app.
+ * Stores tokens in sessionStorage and handles refresh + expiry.
+ */
+
+import type { SessionTokens } from "@sidewalk/types";
+
+const ACCESS_KEY = "sw_access";
+const REFRESH_KEY = "sw_refresh";
+
+export function saveTokens(tokens: SessionTokens): void {
+  sessionStorage.setItem(ACCESS_KEY, tokens.accessToken);
+  sessionStorage.setItem(REFRESH_KEY, tokens.refreshToken);
+}
+
+export function clearTokens(): void {
+  sessionStorage.removeItem(ACCESS_KEY);
+  sessionStorage.removeItem(REFRESH_KEY);
+}
+
+export function getAccessToken(): string | null {
+  return sessionStorage.getItem(ACCESS_KEY);
+}
+
+export function getRefreshToken(): string | null {
+  return sessionStorage.getItem(REFRESH_KEY);
+}
+
+/**
+ * Attempt a silent token refresh.
+ * Returns true on success, false if the session is fully expired.
+ */
+export async function refreshSession(): Promise<boolean> {
+  const refreshToken = getRefreshToken();
+  if (!refreshToken) return false;
+
+  try {
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/auth/refresh`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ refreshToken }),
+      }
+    );
+
+    if (!res.ok) {
+      clearTokens();
+      return false;
+    }
+
+    const tokens: SessionTokens = await res.json();
+    saveTokens(tokens);
+    return true;
+  } catch {
+    clearTokens();
+    return false;
+  }
+}
+
+/**
+ * Build an Authorization header, refreshing the session if needed.
+ * Returns null when the session is fully expired.
+ */
+export async function getAuthHeader(): Promise<Record<string, string> | null> {
+  let token = getAccessToken();
+  if (!token) {
+    const ok = await refreshSession();
+    if (!ok) return null;
+    token = getAccessToken();
+  }
+  return token ? { Authorization: `Bearer ${token}` } : null;
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,0 +1,23 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+const PROTECTED = ["/dashboard", "/report", "/profile", "/admin"];
+
+export function middleware(request: NextRequest): NextResponse {
+  const { pathname, origin } = request.nextUrl;
+
+  const isProtected = PROTECTED.some((p) => pathname.startsWith(p));
+  if (!isProtected) return NextResponse.next();
+
+  // Access token is stored client-side (sessionStorage), so the middleware
+  // checks for a lightweight session cookie set on login instead.
+  const hasSession = request.cookies.has("sw_session");
+  if (hasSession) return NextResponse.next();
+
+  const loginUrl = new URL("/login", origin);
+  loginUrl.searchParams.set("next", pathname);
+  return NextResponse.redirect(loginUrl);
+}
+
+export const config = {
+  matcher: ["/dashboard/:path*", "/report/:path*", "/profile/:path*", "/admin/:path*"],
+};


### PR DESCRIPTION
Closes #345, Closes #346, Closes #347, Closes #348

Adds four auth screens to the Next.js web app:

- `/verify-email` — post-signup holding screen explaining the verification step (#345)
- `/forgot-password` — reset-request form with neutral response (no account enumeration) (#346)
- `/reset-password?token=…` — token-consuming form with explicit invalid/expired states (#347)
- `/session-expired` — clear landing page for ended sessions (#348)

Supporting additions:
- `lib/authClient.ts` — token storage, silent refresh, and auth header helper
- `middleware.ts` — Next.js edge middleware that redirects unauthenticated requests to `/login?next=…`
- Shared `.auth-card` CSS in `globals.css` used by all four screens