### PR TITLE
feat(web): shared auth client and localization-ready auth copy

### DIFF
--- a/apps/web/app/forgot-password/page.tsx
+++ b/apps/web/app/forgot-password/page.tsx
@@ -3,9 +3,9 @@
 import { useState, type ReactElement, type FormEvent } from "react";
 import type {
   PasswordResetRequestRequest,
-  PasswordResetRequestResponse,
-  AuthErrorResponse,
 } from "@sidewalk/types";
+import { authMessages } from "../../lib/authCopy";
+import { requestPasswordReset } from "../../lib/authClient";
 
 type State = "idle" | "loading" | "done" | "error";
 
@@ -19,41 +19,23 @@ export default function ForgotPasswordPage(): ReactElement {
     const email = (e.currentTarget.elements.namedItem("email") as HTMLInputElement).value;
     const body: PasswordResetRequestRequest = { email };
 
-    try {
-      const res = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL}/auth/password-reset/request`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(body),
-        }
-      );
-
-      if (!res.ok) {
-        const err: AuthErrorResponse = await res.json();
-        setErrorMsg(err.message);
-        setState("error");
-        return;
-      }
-
-      const _data: PasswordResetRequestResponse = await res.json();
-      setState("done");
-    } catch {
-      setErrorMsg("Something went wrong. Please try again.");
+    const result = await requestPasswordReset(body);
+    if (!result.ok) {
+      setErrorMsg(result.error.message ?? authMessages.genericError);
       setState("error");
+      return;
     }
+
+    setState("done");
   }
 
   if (state === "done") {
     return (
       <main className="page-shell">
         <div className="auth-card">
-          <p className="eyebrow">Request sent</p>
-          <h1 className="auth-heading">Check your inbox</h1>
-          <p className="auth-body">
-            If that address is registered, a reset link is on its way. Check
-            your spam folder if it doesn&apos;t arrive within a few minutes.
-          </p>
+          <p className="eyebrow">{authMessages.resetPassword.requestDone.eyebrow}</p>
+          <h1 className="auth-heading">{authMessages.resetPassword.requestDone.heading}</h1>
+          <p className="auth-body">{authMessages.resetPassword.requestDone.body}</p>
         </div>
       </main>
     );
@@ -62,16 +44,13 @@ export default function ForgotPasswordPage(): ReactElement {
   return (
     <main className="page-shell">
       <div className="auth-card">
-        <p className="eyebrow">Account recovery</p>
-        <h1 className="auth-heading">Reset your password</h1>
-        <p className="auth-body">
-          Enter your email and we&apos;ll send a reset link. We won&apos;t
-          confirm whether the address is registered.
-        </p>
+        <p className="eyebrow">{authMessages.resetPassword.request.eyebrow}</p>
+        <h1 className="auth-heading">{authMessages.resetPassword.request.heading}</h1>
+        <p className="auth-body">{authMessages.resetPassword.request.body}</p>
 
         <form onSubmit={handleSubmit} className="auth-form" noValidate>
           <label className="auth-label" htmlFor="email">
-            Email address
+            {authMessages.resetPassword.request.emailLabel}
           </label>
           <input
             id="email"
@@ -94,7 +73,9 @@ export default function ForgotPasswordPage(): ReactElement {
             className="auth-button"
             disabled={state === "loading"}
           >
-            {state === "loading" ? "Sending…" : "Send reset link"}
+            {state === "loading"
+              ? authMessages.resetPassword.request.submitLoading
+              : authMessages.resetPassword.request.submitIdle}
           </button>
         </form>
       </div>

--- a/apps/web/app/reset-password/page.tsx
+++ b/apps/web/app/reset-password/page.tsx
@@ -4,9 +4,9 @@ import { useState, type ReactElement, type FormEvent } from "react";
 import { useSearchParams } from "next/navigation";
 import type {
   PasswordResetCompleteRequest,
-  PasswordResetCompleteResponse,
-  AuthErrorResponse,
 } from "@sidewalk/types";
+import { authMessages } from "../../lib/authCopy";
+import { completePasswordReset } from "../../lib/authClient";
 
 type State = "idle" | "loading" | "done" | "invalid" | "error";
 
@@ -23,7 +23,7 @@ export default function ResetPasswordPage(): ReactElement {
     const confirm = (els.namedItem("confirm") as HTMLInputElement).value;
 
     if (password !== confirm) {
-      setErrorMsg("Passwords do not match.");
+      setErrorMsg(authMessages.resetPassword.complete.mismatchError);
       setState("error");
       return;
     }
@@ -31,47 +31,32 @@ export default function ResetPasswordPage(): ReactElement {
     setState("loading");
     const body: PasswordResetCompleteRequest = { token, password };
 
-    try {
-      const res = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL}/auth/password-reset/complete`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(body),
-        }
-      );
-
-      if (!res.ok) {
-        const err: AuthErrorResponse = await res.json();
-        if (err.code === "INVALID_TOKEN" || err.code === "TOKEN_EXPIRED") {
-          setState("invalid");
-        } else {
-          setErrorMsg(err.message);
-          setState("error");
-        }
-        return;
+    const result = await completePasswordReset(body);
+    if (!result.ok) {
+      if (
+        result.error.code === "INVALID_TOKEN" ||
+        result.error.code === "TOKEN_EXPIRED"
+      ) {
+        setState("invalid");
+      } else {
+        setErrorMsg(result.error.message ?? authMessages.genericError);
+        setState("error");
       }
-
-      const _data: PasswordResetCompleteResponse = await res.json();
-      setState("done");
-    } catch {
-      setErrorMsg("Something went wrong. Please try again.");
-      setState("error");
+      return;
     }
+
+    setState("done");
   }
 
   if (state === "done") {
     return (
       <main className="page-shell">
         <div className="auth-card">
-          <p className="eyebrow">All set</p>
-          <h1 className="auth-heading">Password updated</h1>
-          <p className="auth-body">
-            Your password has been changed. You can now sign in with your new
-            credentials.
-          </p>
+          <p className="eyebrow">{authMessages.resetPassword.completeDone.eyebrow}</p>
+          <h1 className="auth-heading">{authMessages.resetPassword.completeDone.heading}</h1>
+          <p className="auth-body">{authMessages.resetPassword.completeDone.body}</p>
           <a href="/login" className="auth-button auth-button--inline">
-            Go to sign in
+            {authMessages.resetPassword.completeDone.cta}
           </a>
         </div>
       </main>
@@ -82,14 +67,11 @@ export default function ResetPasswordPage(): ReactElement {
     return (
       <main className="page-shell">
         <div className="auth-card">
-          <p className="eyebrow">Link problem</p>
-          <h1 className="auth-heading">This link is no longer valid</h1>
-          <p className="auth-body">
-            Reset links expire after 1 hour and can only be used once. Request
-            a new one to continue.
-          </p>
+          <p className="eyebrow">{authMessages.resetPassword.invalidLink.eyebrow}</p>
+          <h1 className="auth-heading">{authMessages.resetPassword.invalidLink.heading}</h1>
+          <p className="auth-body">{authMessages.resetPassword.invalidLink.body}</p>
           <a href="/forgot-password" className="auth-button auth-button--inline">
-            Request a new link
+            {authMessages.resetPassword.invalidLink.cta}
           </a>
         </div>
       </main>
@@ -99,12 +81,12 @@ export default function ResetPasswordPage(): ReactElement {
   return (
     <main className="page-shell">
       <div className="auth-card">
-        <p className="eyebrow">Account recovery</p>
-        <h1 className="auth-heading">Choose a new password</h1>
+        <p className="eyebrow">{authMessages.resetPassword.complete.eyebrow}</p>
+        <h1 className="auth-heading">{authMessages.resetPassword.complete.heading}</h1>
 
         <form onSubmit={handleSubmit} className="auth-form" noValidate>
           <label className="auth-label" htmlFor="password">
-            New password
+            {authMessages.resetPassword.complete.passwordLabel}
           </label>
           <input
             id="password"
@@ -118,7 +100,7 @@ export default function ResetPasswordPage(): ReactElement {
           />
 
           <label className="auth-label" htmlFor="confirm">
-            Confirm password
+            {authMessages.resetPassword.complete.confirmLabel}
           </label>
           <input
             id="confirm"
@@ -141,7 +123,9 @@ export default function ResetPasswordPage(): ReactElement {
             className="auth-button"
             disabled={state === "loading"}
           >
-            {state === "loading" ? "Saving…" : "Set new password"}
+            {state === "loading"
+              ? authMessages.resetPassword.complete.submitLoading
+              : authMessages.resetPassword.complete.submitIdle}
           </button>
         </form>
       </div>

--- a/apps/web/lib/authClient.ts
+++ b/apps/web/lib/authClient.ts
@@ -4,6 +4,13 @@
  */
 
 import type { SessionTokens } from "@sidewalk/types";
+import type {
+  AuthErrorResponse,
+  PasswordResetCompleteRequest,
+  PasswordResetCompleteResponse,
+  PasswordResetRequestRequest,
+  PasswordResetRequestResponse,
+} from "@sidewalk/types";
 
 const ACCESS_KEY = "sw_access";
 const REFRESH_KEY = "sw_refresh";
@@ -26,6 +33,80 @@ export function getRefreshToken(): string | null {
   return sessionStorage.getItem(REFRESH_KEY);
 }
 
+const UNKNOWN_ERROR: AuthErrorResponse = {
+  code: "VALIDATION_ERROR",
+  message: "Something went wrong. Please try again.",
+};
+
+type AuthSuccess<T> = {
+  ok: true;
+  data: T;
+};
+
+type AuthFailure = {
+  ok: false;
+  error: AuthErrorResponse;
+};
+
+export type AuthResult<T> = AuthSuccess<T> | AuthFailure;
+
+function endpoint(path: string): string {
+  return `${process.env.NEXT_PUBLIC_API_URL}${path}`;
+}
+
+async function parseAuthError(res: Response): Promise<AuthErrorResponse> {
+  try {
+    const err = (await res.json()) as Partial<AuthErrorResponse>;
+    if (typeof err.message === "string" && typeof err.code === "string") {
+      return err as AuthErrorResponse;
+    }
+    return UNKNOWN_ERROR;
+  } catch {
+    return UNKNOWN_ERROR;
+  }
+}
+
+async function authRequest<TResponse, TBody>(
+  path: string,
+  body: TBody
+): Promise<AuthResult<TResponse>> {
+  try {
+    const res = await fetch(endpoint(path), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      credentials: "include",
+    });
+
+    if (!res.ok) {
+      return { ok: false, error: await parseAuthError(res) };
+    }
+
+    const data = (await res.json()) as TResponse;
+    return { ok: true, data };
+  } catch {
+    return { ok: false, error: UNKNOWN_ERROR };
+  }
+}
+
+export function requestPasswordReset(
+  body: PasswordResetRequestRequest
+): Promise<AuthResult<PasswordResetRequestResponse>> {
+  return authRequest<PasswordResetRequestResponse, PasswordResetRequestRequest>(
+    "/auth/password-reset/request",
+    body
+  );
+}
+
+export function completePasswordReset(
+  body: PasswordResetCompleteRequest
+): Promise<AuthResult<PasswordResetCompleteResponse>> {
+  return authRequest<PasswordResetCompleteResponse, PasswordResetCompleteRequest>(
+    "/auth/password-reset/complete",
+    body
+  );
+}
+
 /**
  * Attempt a silent token refresh.
  * Returns true on success, false if the session is fully expired.
@@ -36,11 +117,12 @@ export async function refreshSession(): Promise<boolean> {
 
   try {
     const res = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/auth/refresh`,
+      endpoint("/auth/refresh"),
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ refreshToken }),
+        credentials: "include",
       }
     );
 

--- a/apps/web/lib/authCopy.ts
+++ b/apps/web/lib/authCopy.ts
@@ -1,0 +1,42 @@
+/**
+ * Keep auth-facing copy in one place so future locale files can mirror this shape.
+ */
+export const authMessages = {
+  genericError: "Something went wrong. Please try again.",
+  resetPassword: {
+    request: {
+      eyebrow: "Account recovery",
+      heading: "Reset your password",
+      body: "Enter your email and we'll send a reset link. We won't confirm whether the address is registered.",
+      emailLabel: "Email address",
+      submitIdle: "Send reset link",
+      submitLoading: "Sending…",
+    },
+    requestDone: {
+      eyebrow: "Request sent",
+      heading: "Check your inbox",
+      body: "If that address is registered, a reset link is on its way. Check your spam folder if it doesn't arrive within a few minutes.",
+    },
+    complete: {
+      eyebrow: "Account recovery",
+      heading: "Choose a new password",
+      passwordLabel: "New password",
+      confirmLabel: "Confirm password",
+      submitIdle: "Set new password",
+      submitLoading: "Saving…",
+      mismatchError: "Passwords do not match.",
+    },
+    completeDone: {
+      eyebrow: "All set",
+      heading: "Password updated",
+      body: "Your password has been changed. You can now sign in with your new credentials.",
+      cta: "Go to sign in",
+    },
+    invalidLink: {
+      eyebrow: "Link problem",
+      heading: "This link is no longer valid",
+      body: "Reset links expire after 1 hour and can only be used once. Request a new one to continue.",
+      cta: "Request a new link",
+    },
+  },
+} as const;


### PR DESCRIPTION
## Summary
- add a typed shared web auth request layer for password reset request/complete flows
- centralize credential behavior and error conversion in one client module
- move auth page copy into a single message structure to make future localization straightforward

## Details
- introduced `authRequest` with typed success/failure results and centralized fallback error handling
- added `requestPasswordReset` and `completePasswordReset` helpers in `apps/web/lib/authClient.ts`
- added `apps/web/lib/authCopy.ts` for localization-ready auth messaging
- refactored forgot/reset password pages to use shared client methods and centralized copy

## Validation
- `pnpm --filter @sidewalk/web lint`
- `pnpm --filter @sidewalk/web typecheck`
- `pnpm --filter @sidewalk/web build` *(fails due to pre-existing `useSearchParams()` suspense requirement on `/reset-password`)*

Closes #356
Closes #355
Closes #354
Closes #353