### PR TITLE
feat(web): add shared anti-bot challenge extension point

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ The initial scaffold intentionally keeps secrets and third-party dependencies mi
 
 This repo is being prepared for public contributors. Keep changes scoped, document new environment variables, and prefer shared contracts in `packages/types` when multiple apps need the same shape.
 
+### Web auth challenge extension point
+
+The web auth client includes a shared anti-bot hook in `apps/web/lib/authClient.ts`:
+
+- `setAuthChallengeHandler(handler)` registers a future challenge provider
+- `register(...)` and `login(...)` both request an optional `challengeToken` via that handler
+
+By default no challenge is required, so current flows stay simple. When a CAPTCHA or other challenge is introduced, wire it once with `setAuthChallengeHandler` and both signup/login calls will reuse it.
+
 ## License
 
 MIT

--- a/apps/web/lib/authClient.ts
+++ b/apps/web/lib/authClient.ts
@@ -3,10 +3,113 @@
  * Stores tokens in sessionStorage and handles refresh + expiry.
  */
 
-import type { SessionTokens } from "@sidewalk/types";
+import type {
+  LoginRequest,
+  LoginResponse,
+  RegisterRequest,
+  RegisterResponse,
+  SessionTokens,
+} from "@sidewalk/types";
 
 const ACCESS_KEY = "sw_access";
 const REFRESH_KEY = "sw_refresh";
+
+export type AuthChallengeContext = {
+  flow: "login" | "signup";
+  email?: string;
+};
+
+export type AuthChallengeResult = {
+  token?: string;
+};
+
+export type AuthChallengeHandler = (
+  context: AuthChallengeContext
+) => Promise<AuthChallengeResult>;
+
+let authChallengeHandler: AuthChallengeHandler | null = null;
+
+/**
+ * Register a future anti-bot challenge handler (e.g. CAPTCHA, device check).
+ * Current behavior is unchanged until a handler is provided by the UI layer.
+ */
+export function setAuthChallengeHandler(
+  handler: AuthChallengeHandler | null
+): void {
+  authChallengeHandler = handler;
+}
+
+async function getChallengeToken(
+  context: AuthChallengeContext
+): Promise<string | undefined> {
+  if (!authChallengeHandler) return undefined;
+  const result = await authChallengeHandler(context);
+  return result.token;
+}
+
+function endpoint(path: string): string {
+  return `${process.env.NEXT_PUBLIC_API_URL}${path}`;
+}
+
+type AuthResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; message: string };
+
+async function postAuth<TResponse, TBody>(
+  path: string,
+  body: TBody
+): Promise<AuthResult<TResponse>> {
+  try {
+    const res = await fetch(endpoint(path), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      let message = "Request failed.";
+      try {
+        const data = (await res.json()) as { message?: string };
+        if (typeof data.message === "string") message = data.message;
+      } catch {
+        // Keep fallback message when response body is not parseable JSON.
+      }
+      return { ok: false, message };
+    }
+
+    const data = (await res.json()) as TResponse;
+    return { ok: true, data };
+  } catch {
+    return { ok: false, message: "Network error. Please try again." };
+  }
+}
+
+export async function register(
+  body: RegisterRequest
+): Promise<AuthResult<RegisterResponse>> {
+  const challengeToken = await getChallengeToken({
+    flow: "signup",
+    email: body.email,
+  });
+  return postAuth<RegisterResponse, RegisterRequest & { challengeToken?: string }>(
+    "/auth/register",
+    { ...body, challengeToken }
+  );
+}
+
+export async function login(
+  body: LoginRequest
+): Promise<AuthResult<LoginResponse>> {
+  const challengeToken = await getChallengeToken({
+    flow: "login",
+    email: body.email,
+  });
+  return postAuth<LoginResponse, LoginRequest & { challengeToken?: string }>(
+    "/auth/login",
+    { ...body, challengeToken }
+  );
+}
 
 export function saveTokens(tokens: SessionTokens): void {
   sessionStorage.setItem(ACCESS_KEY, tokens.accessToken);
@@ -36,11 +139,12 @@ export async function refreshSession(): Promise<boolean> {
 
   try {
     const res = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/auth/refresh`,
+      endpoint("/auth/refresh"),
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ refreshToken }),
+        credentials: "include",
       }
     );
 


### PR DESCRIPTION
## Summary
- add a shared auth challenge extension hook in the web auth client
- apply the hook in both signup and login request paths without changing current default behavior
- document where future CAPTCHA/challenge providers should be wired


## Details
- introduced `setAuthChallengeHandler` plus challenge context/result types in `apps/web/lib/authClient.ts`
- wired optional `challengeToken` into shared `register(...)` and `login(...)` client methods
- kept the default flow unchanged when no handler is registered
- added contributor notes in `README.md` for future challenge-provider integration

## Validation
- `pnpm --filter @sidewalk/web typecheck` ✅
- `pnpm --filter @sidewalk/web lint` ❌ (pre-existing unused `_data` vars in existing auth pages)
- `pnpm --filter @sidewalk/web build` ❌ (fails for same pre-existing lint issue)

Closes #363
Closes #361
Closes #362
Closes #364