### PR TITLE
feat(mobile): implement auth + recovery flow

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,24 +1,471 @@
 import { StatusBar } from "expo-status-bar";
-import { SafeAreaView, StyleSheet, Text, View } from "react-native";
+import { useEffect, useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  Linking,
+  Pressable,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
 
-import type { AuthStatus } from "@sidewalk/types";
+import type { AuthErrorCode, LoginResponse, SessionTokens } from "@sidewalk/types";
 
-const authMilestone: AuthStatus = {
-  phase: "foundation",
-  ready: false,
-  nextStep: "Use this workspace to implement mobile signup, login, and recovery during Batch 1."
-};
+import {
+  completePasswordReset,
+  login,
+  memoryTokenStore,
+  requestPasswordReset,
+} from "./src/lib/authClient";
+import { parseResetLink } from "./src/lib/deepLinks";
+import {
+  friendlyAuthMessage,
+  privacySafeResetMessage,
+} from "./src/lib/authMessaging";
+import { isValidEmail, validatePassword } from "./src/lib/validation";
 
-export default function App() {
+type Route =
+  | { name: "login" }
+  | { name: "forgotPassword" }
+  | { name: "resetPassword"; token?: string }
+  | { name: "verificationPending"; email?: string }
+  | { name: "home" };
+
+type AuthState =
+  | { status: "signedOut" }
+  | { status: "unverified"; session: LoginResponse }
+  | { status: "signedIn"; session: LoginResponse };
+
+function apiUrlHint(): string | null {
+  return process.env.EXPO_PUBLIC_API_URL ?? null;
+}
+
+function PrimaryButton(props: {
+  label: string;
+  onPress: () => void;
+  disabled?: boolean;
+  busy?: boolean;
+}) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      onPress={props.onPress}
+      disabled={props.disabled || props.busy}
+      style={({ pressed }) => [
+        styles.button,
+        (props.disabled || props.busy) && styles.buttonDisabled,
+        pressed && !(props.disabled || props.busy) && styles.buttonPressed,
+      ]}
+    >
+      {props.busy ? (
+        <ActivityIndicator color="#fffaf3" />
+      ) : (
+        <Text style={styles.buttonLabel}>{props.label}</Text>
+      )}
+    </Pressable>
+  );
+}
+
+function LinkButton(props: { label: string; onPress: () => void }) {
+  return (
+    <Pressable accessibilityRole="button" onPress={props.onPress}>
+      <Text style={styles.link}>{props.label}</Text>
+    </Pressable>
+  );
+}
+
+function ScreenShell(props: { title: string; subtitle?: string; children: React.ReactNode }) {
+  const urlHint = apiUrlHint();
   return (
     <SafeAreaView style={styles.safeArea}>
       <StatusBar style="dark" />
       <View style={styles.card}>
-        <Text style={styles.eyebrow}>Mobile Workspace</Text>
-        <Text style={styles.title}>Authentication starts here too.</Text>
-        <Text style={styles.body}>{authMilestone.nextStep}</Text>
+        <Text style={styles.eyebrow}>Sidewalk</Text>
+        <Text style={styles.title}>{props.title}</Text>
+        {props.subtitle ? <Text style={styles.subtitle}>{props.subtitle}</Text> : null}
+        {!urlHint ? (
+          <View style={styles.banner}>
+            <Text style={styles.bannerTitle}>Missing API URL</Text>
+            <Text style={styles.bannerBody}>Set EXPO_PUBLIC_API_URL to your API base URL.</Text>
+          </View>
+        ) : null}
+        <View style={styles.content}>{props.children}</View>
       </View>
     </SafeAreaView>
+  );
+}
+
+function ErrorNotice(props: { message?: string | null }) {
+  if (!props.message) return null;
+  return (
+    <View style={styles.noticeError} accessibilityLiveRegion="polite">
+      <Text style={styles.noticeErrorText}>{props.message}</Text>
+    </View>
+  );
+}
+
+function SuccessNotice(props: { message?: string | null }) {
+  if (!props.message) return null;
+  return (
+    <View style={styles.noticeSuccess} accessibilityLiveRegion="polite">
+      <Text style={styles.noticeSuccessText}>{props.message}</Text>
+    </View>
+  );
+}
+
+function mapAuthError(code: AuthErrorCode): string {
+  return friendlyAuthMessage(code);
+}
+
+export default function App() {
+  const [route, setRoute] = useState<Route>({ name: "login" });
+  const [authState, setAuthState] = useState<AuthState>({ status: "signedOut" });
+
+  useEffect(() => {
+    function handleUrl(nextUrl: string | null | undefined) {
+      if (!nextUrl) return;
+      const reset = parseResetLink(nextUrl);
+      if (reset) setRoute({ name: "resetPassword", token: reset.token });
+    }
+
+    Linking.getInitialURL().then(handleUrl).catch(() => {});
+    const sub = Linking.addEventListener("url", (event) => handleUrl(event.url));
+    return () => sub.remove();
+  }, []);
+
+  const session = authState.status === "signedOut" ? null : authState.session;
+  const headerEmail = session?.account.email;
+
+  if (route.name === "login") {
+    return (
+      <LoginScreen
+        onLoginSuccess={(sessionData, tokens) => {
+          memoryTokenStore.set(tokens);
+          if (sessionData.account.verified) {
+            setAuthState({ status: "signedIn", session: sessionData });
+            setRoute({ name: "home" });
+          } else {
+            setAuthState({ status: "unverified", session: sessionData });
+            setRoute({ name: "verificationPending", email: sessionData.account.email });
+          }
+        }}
+        onForgotPassword={() => setRoute({ name: "forgotPassword" })}
+      />
+    );
+  }
+
+  if (route.name === "forgotPassword") {
+    return (
+      <PasswordResetRequestScreen
+        onDone={() => setRoute({ name: "login" })}
+        onBack={() => setRoute({ name: "login" })}
+      />
+    );
+  }
+
+  if (route.name === "resetPassword") {
+    return (
+      <PasswordResetCompleteScreen
+        initialToken={route.token}
+        onBack={() => setRoute({ name: "login" })}
+        onSuccess={() => setRoute({ name: "login" })}
+      />
+    );
+  }
+
+  if (route.name === "verificationPending") {
+    return (
+      <VerificationPendingScreen
+        email={route.email ?? headerEmail}
+        onBackToLogin={() => {
+          memoryTokenStore.clear();
+          setAuthState({ status: "signedOut" });
+          setRoute({ name: "login" });
+        }}
+      />
+    );
+  }
+
+  return (
+    <HomeScreen
+      email={headerEmail ?? "Signed in"}
+      verified={session?.account.verified ?? false}
+      onLogout={() => {
+        memoryTokenStore.clear();
+        setAuthState({ status: "signedOut" });
+        setRoute({ name: "login" });
+      }}
+    />
+  );
+}
+
+function LoginScreen(props: {
+  onLoginSuccess: (session: LoginResponse, tokens: SessionTokens) => void;
+  onForgotPassword: () => void;
+}) {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const canSubmit = useMemo(() => {
+    return isValidEmail(email) && password.trim().length > 0 && !busy;
+  }, [busy, email, password]);
+
+  async function handleSubmit() {
+    setBusy(true);
+    setError(null);
+    const result = await login({ email: email.trim(), password });
+    setBusy(false);
+
+    if (!result.ok) {
+      setError(mapAuthError(result.error.code));
+      return;
+    }
+
+    props.onLoginSuccess(result.data, {
+      accessToken: result.data.accessToken,
+      refreshToken: result.data.refreshToken,
+    });
+  }
+
+  return (
+    <ScreenShell
+      title="Sign in"
+      subtitle="Use your email and password to access your account."
+    >
+      <ErrorNotice message={error} />
+      <Text style={styles.label}>Email</Text>
+      <TextInput
+        autoCapitalize="none"
+        autoComplete="email"
+        keyboardType="email-address"
+        value={email}
+        onChangeText={setEmail}
+        placeholder="you@example.com"
+        placeholderTextColor="#8a7b6b"
+        style={styles.input}
+      />
+      <Text style={styles.label}>Password</Text>
+      <TextInput
+        secureTextEntry
+        autoCapitalize="none"
+        value={password}
+        onChangeText={setPassword}
+        placeholder="Your password"
+        placeholderTextColor="#8a7b6b"
+        style={styles.input}
+      />
+
+      <PrimaryButton label="Sign in" onPress={handleSubmit} disabled={!canSubmit} busy={busy} />
+      <View style={styles.row}>
+        <LinkButton label="Forgot password?" onPress={props.onForgotPassword} />
+      </View>
+    </ScreenShell>
+  );
+}
+
+function PasswordResetRequestScreen(props: { onBack: () => void; onDone: () => void }) {
+  const [email, setEmail] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const canSubmit = useMemo(() => {
+    return isValidEmail(email) && !busy;
+  }, [busy, email]);
+
+  async function handleSubmit() {
+    setBusy(true);
+    setError(null);
+    setSuccess(null);
+
+    const result = await requestPasswordReset({ email: email.trim() });
+    setBusy(false);
+
+    if (!result.ok) {
+      if (result.error.code === "VALIDATION_ERROR") {
+        setError("Enter a valid email address.");
+        return;
+      }
+      setError(mapAuthError(result.error.code));
+      setSuccess(privacySafeResetMessage());
+      return;
+    }
+
+    setSuccess(privacySafeResetMessage());
+  }
+
+  return (
+    <ScreenShell
+      title="Reset password"
+      subtitle="We’ll email you a link to reset your password."
+    >
+      <ErrorNotice message={error} />
+      <SuccessNotice message={success} />
+
+      <Text style={styles.label}>Email</Text>
+      <TextInput
+        autoCapitalize="none"
+        autoComplete="email"
+        keyboardType="email-address"
+        value={email}
+        onChangeText={setEmail}
+        placeholder="you@example.com"
+        placeholderTextColor="#8a7b6b"
+        style={styles.input}
+      />
+
+      <PrimaryButton
+        label="Send reset link"
+        onPress={handleSubmit}
+        disabled={!canSubmit}
+        busy={busy}
+      />
+
+      <View style={styles.rowBetween}>
+        <LinkButton label="Back to sign in" onPress={props.onBack} />
+        {success ? <LinkButton label="Done" onPress={props.onDone} /> : null}
+      </View>
+    </ScreenShell>
+  );
+}
+
+function PasswordResetCompleteScreen(props: {
+  initialToken?: string;
+  onBack: () => void;
+  onSuccess: () => void;
+}) {
+  const [token, setToken] = useState(props.initialToken ?? "");
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const canSubmit = useMemo(() => {
+    const validation = validatePassword(password);
+    return (
+      token.trim().length > 0 &&
+      validation.ok &&
+      password === confirm &&
+      !busy
+    );
+  }, [busy, confirm, password, token]);
+
+  async function handleSubmit() {
+    const validation = validatePassword(password);
+    if (!validation.ok) {
+      setError(validation.message ?? "Please check your password.");
+      return;
+    }
+    if (password !== confirm) {
+      setError("Passwords do not match.");
+      return;
+    }
+
+    setBusy(true);
+    setError(null);
+    setSuccess(null);
+
+    const result = await completePasswordReset({ token: token.trim(), password });
+    setBusy(false);
+
+    if (!result.ok) {
+      setError(mapAuthError(result.error.code));
+      return;
+    }
+
+    setSuccess("Password updated. You can sign in with your new password.");
+  }
+
+  return (
+    <ScreenShell
+      title="Choose a new password"
+      subtitle="Use the token from your reset link to finish updating your password."
+    >
+      <ErrorNotice message={error} />
+      <SuccessNotice message={success} />
+
+      <Text style={styles.label}>Reset token</Text>
+      <TextInput
+        autoCapitalize="none"
+        value={token}
+        onChangeText={setToken}
+        placeholder="Paste token from link"
+        placeholderTextColor="#8a7b6b"
+        style={styles.input}
+      />
+
+      <Text style={styles.label}>New password</Text>
+      <TextInput
+        secureTextEntry
+        autoCapitalize="none"
+        value={password}
+        onChangeText={setPassword}
+        placeholder="At least 8 characters"
+        placeholderTextColor="#8a7b6b"
+        style={styles.input}
+      />
+
+      <Text style={styles.label}>Confirm password</Text>
+      <TextInput
+        secureTextEntry
+        autoCapitalize="none"
+        value={confirm}
+        onChangeText={setConfirm}
+        placeholder="Re-enter new password"
+        placeholderTextColor="#8a7b6b"
+        style={styles.input}
+      />
+
+      <PrimaryButton
+        label={success ? "Back to sign in" : "Update password"}
+        onPress={success ? props.onSuccess : handleSubmit}
+        disabled={success ? false : !canSubmit}
+        busy={busy}
+      />
+
+      <View style={styles.row}>
+        <LinkButton label="Back" onPress={props.onBack} />
+      </View>
+    </ScreenShell>
+  );
+}
+
+function VerificationPendingScreen(props: { email?: string; onBackToLogin: () => void }) {
+  const message = props.email
+    ? `We sent a verification email to ${props.email}. Please verify your account to continue.`
+    : "Check your inbox for the verification email. Please verify your account to continue.";
+
+  return (
+    <ScreenShell
+      title="Verify your email"
+      subtitle="You’re almost done. Complete verification to activate your account."
+    >
+      <View style={styles.noticeInfo}>
+        <Text style={styles.noticeInfoText}>{message}</Text>
+      </View>
+
+      <Text style={styles.body}>
+        Resend and “open inbox” actions will be added soon. For now, return after verifying.
+      </Text>
+
+      <PrimaryButton label="Back to sign in" onPress={props.onBackToLogin} />
+    </ScreenShell>
+  );
+}
+
+function HomeScreen(props: { email: string; verified: boolean; onLogout: () => void }) {
+  return (
+    <ScreenShell title="You’re signed in" subtitle={props.verified ? "Verified account" : "Unverified account"}>
+      <View style={styles.noticeSuccess}>
+        <Text style={styles.noticeSuccessText}>{props.email}</Text>
+      </View>
+      <PrimaryButton label="Sign out" onPress={props.onLogout} />
+    </ScreenShell>
   );
 }
 
@@ -28,7 +475,7 @@ const styles = StyleSheet.create({
     backgroundColor: "#f4efe4",
     alignItems: "center",
     justifyContent: "center",
-    padding: 24
+    padding: 24,
   },
   card: {
     width: "100%",
@@ -40,25 +487,135 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.12,
     shadowRadius: 20,
     shadowOffset: { width: 0, height: 10 },
-    elevation: 4
+    elevation: 4,
   },
   eyebrow: {
-    marginBottom: 12,
+    marginBottom: 8,
     color: "#7a3414",
     fontSize: 12,
     fontWeight: "700",
     letterSpacing: 1.8,
-    textTransform: "uppercase"
+    textTransform: "uppercase",
   },
   title: {
     fontSize: 28,
     fontWeight: "700",
-    color: "#22170e"
+    color: "#22170e",
+  },
+  subtitle: {
+    marginTop: 10,
+    fontSize: 15,
+    lineHeight: 22,
+    color: "#574a3d",
+  },
+  content: {
+    marginTop: 18,
+    gap: 12,
+  },
+  label: {
+    marginTop: 4,
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#22170e",
+  },
+  input: {
+    height: 48,
+    borderWidth: 1,
+    borderColor: "#e0d3c3",
+    borderRadius: 14,
+    paddingHorizontal: 14,
+    backgroundColor: "#ffffff",
+    color: "#22170e",
+  },
+  button: {
+    height: 48,
+    borderRadius: 16,
+    backgroundColor: "#7a3414",
+    alignItems: "center",
+    justifyContent: "center",
+    marginTop: 6,
+  },
+  buttonPressed: {
+    opacity: 0.9,
+  },
+  buttonDisabled: {
+    opacity: 0.45,
+  },
+  buttonLabel: {
+    color: "#fffaf3",
+    fontSize: 16,
+    fontWeight: "700",
+  },
+  link: {
+    color: "#7a3414",
+    fontWeight: "700",
+    paddingVertical: 8,
+  },
+  row: {
+    flexDirection: "row",
+    justifyContent: "flex-start",
+  },
+  rowBetween: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  noticeError: {
+    borderRadius: 16,
+    padding: 12,
+    backgroundColor: "#ffe8e8",
+    borderWidth: 1,
+    borderColor: "#ffb7b7",
+  },
+  noticeErrorText: {
+    color: "#7a1414",
+    fontWeight: "600",
+    lineHeight: 20,
+  },
+  noticeSuccess: {
+    borderRadius: 16,
+    padding: 12,
+    backgroundColor: "#e8fff1",
+    borderWidth: 1,
+    borderColor: "#98e8b8",
+  },
+  noticeSuccessText: {
+    color: "#145a2c",
+    fontWeight: "600",
+    lineHeight: 20,
+  },
+  noticeInfo: {
+    borderRadius: 16,
+    padding: 12,
+    backgroundColor: "#f1f0ff",
+    borderWidth: 1,
+    borderColor: "#c7c3ff",
+  },
+  noticeInfoText: {
+    color: "#2a287a",
+    fontWeight: "600",
+    lineHeight: 20,
+  },
+  banner: {
+    marginTop: 14,
+    borderRadius: 16,
+    padding: 12,
+    backgroundColor: "#fff3d9",
+    borderWidth: 1,
+    borderColor: "#ffd99a",
+  },
+  bannerTitle: {
+    fontWeight: "800",
+    color: "#7a3414",
+    marginBottom: 4,
+  },
+  bannerBody: {
+    color: "#574a3d",
+    lineHeight: 18,
   },
   body: {
-    marginTop: 12,
-    fontSize: 16,
-    lineHeight: 24,
-    color: "#574a3d"
-  }
+    fontSize: 15,
+    lineHeight: 22,
+    color: "#574a3d",
+  },
 });

--- a/apps/mobile/DEEP_LINKS.md
+++ b/apps/mobile/DEEP_LINKS.md
@@ -1,0 +1,19 @@
+# Mobile deep links
+
+This app registers the `sidewalk` scheme (see `apps/mobile/app.json`).
+
+## Password reset completion
+
+When a user opens the password reset email on a phone, the mobile app should be able to receive the reset token and route to the reset completion screen.
+
+Supported formats:
+
+- `sidewalk://reset-password?token=<TOKEN>`
+- `sidewalk://auth/reset-password?token=<TOKEN>`
+- `sidewalk://reset-password/<TOKEN>`
+
+Notes:
+
+- The UI never reveals whether an email address is registered during reset requests.
+- Tokens are treated as opaque strings.
+

--- a/apps/mobile/src/lib/authClient.ts
+++ b/apps/mobile/src/lib/authClient.ts
@@ -1,0 +1,125 @@
+/**
+ * Thin auth client for the Expo mobile app.
+ * Keeps token storage pluggable so we can add persistence/biometrics later.
+ */
+
+import type {
+  AuthErrorResponse,
+  LoginRequest,
+  LoginResponse,
+  PasswordResetCompleteRequest,
+  PasswordResetCompleteResponse,
+  PasswordResetRequestRequest,
+  PasswordResetRequestResponse,
+  SessionTokens,
+} from "@sidewalk/types";
+
+const UNKNOWN_ERROR: AuthErrorResponse = {
+  code: "VALIDATION_ERROR",
+  message: "Something went wrong. Please try again.",
+};
+
+export type AuthSuccess<T> = { ok: true; data: T };
+export type AuthFailure = { ok: false; error: AuthErrorResponse };
+export type AuthResult<T> = AuthSuccess<T> | AuthFailure;
+
+export type TokenStore = {
+  get(): SessionTokens | null;
+  set(tokens: SessionTokens): void;
+  clear(): void;
+};
+
+export const memoryTokenStore: TokenStore = (() => {
+  let tokens: SessionTokens | null = null;
+  return {
+    get() {
+      return tokens;
+    },
+    set(next) {
+      tokens = next;
+    },
+    clear() {
+      tokens = null;
+    },
+  };
+})();
+
+function baseUrl(): string | null {
+  const raw = process.env.EXPO_PUBLIC_API_URL;
+  if (!raw) return null;
+  return raw.endsWith("/") ? raw.slice(0, -1) : raw;
+}
+
+function endpoint(path: string): string {
+  const url = baseUrl();
+  if (!url) {
+    throw new Error("Missing EXPO_PUBLIC_API_URL");
+  }
+  return `${url}${path}`;
+}
+
+async function parseAuthError(res: Response): Promise<AuthErrorResponse> {
+  try {
+    const err = (await res.json()) as Partial<AuthErrorResponse>;
+    if (typeof err.message === "string" && typeof err.code === "string") {
+      return err as AuthErrorResponse;
+    }
+    return UNKNOWN_ERROR;
+  } catch {
+    return UNKNOWN_ERROR;
+  }
+}
+
+async function authRequest<TResponse, TBody>(
+  path: string,
+  body: TBody
+): Promise<AuthResult<TResponse>> {
+  try {
+    const res = await fetch(endpoint(path), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      return { ok: false, error: await parseAuthError(res) };
+    }
+
+    const data = (await res.json()) as TResponse;
+    return { ok: true, data };
+  } catch (error) {
+    if (error instanceof Error && error.message === "Missing EXPO_PUBLIC_API_URL") {
+      return {
+        ok: false,
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Mobile API URL is not configured. Set EXPO_PUBLIC_API_URL and try again.",
+        },
+      };
+    }
+    return { ok: false, error: UNKNOWN_ERROR };
+  }
+}
+
+export function login(body: LoginRequest): Promise<AuthResult<LoginResponse>> {
+  return authRequest<LoginResponse, LoginRequest>("/auth/login", body);
+}
+
+export function requestPasswordReset(
+  body: PasswordResetRequestRequest
+): Promise<AuthResult<PasswordResetRequestResponse>> {
+  return authRequest<PasswordResetRequestResponse, PasswordResetRequestRequest>(
+    "/auth/password-reset/request",
+    body
+  );
+}
+
+export function completePasswordReset(
+  body: PasswordResetCompleteRequest
+): Promise<AuthResult<PasswordResetCompleteResponse>> {
+  return authRequest<PasswordResetCompleteResponse, PasswordResetCompleteRequest>(
+    "/auth/password-reset/complete",
+    body
+  );
+}
+

--- a/apps/mobile/src/lib/authMessaging.ts
+++ b/apps/mobile/src/lib/authMessaging.ts
@@ -1,0 +1,31 @@
+import type { AuthErrorCode } from "@sidewalk/types";
+
+export function friendlyAuthMessage(code: AuthErrorCode): string {
+  switch (code) {
+    case "INVALID_CREDENTIALS":
+      return "Email or password is incorrect.";
+    case "ACCOUNT_UNVERIFIED":
+      return "Your account is not verified yet. Check your inbox for the verification email.";
+    case "ACCOUNT_LOCKED":
+      return "Your account is temporarily locked due to repeated login failures. Please try again later.";
+    case "RATE_LIMITED":
+      return "Too many attempts. Please wait a bit and try again.";
+    case "TOKEN_EXPIRED":
+      return "This link has expired. Request a new password reset email.";
+    case "INVALID_TOKEN":
+      return "This link is invalid. Request a new password reset email.";
+    case "VALIDATION_ERROR":
+      return "Please check your details and try again.";
+    case "EMAIL_TAKEN":
+      return "This email is already registered.";
+    case "SESSION_NOT_FOUND":
+      return "Your session has expired. Please sign in again.";
+    default:
+      return "Something went wrong. Please try again.";
+  }
+}
+
+export function privacySafeResetMessage(): string {
+  return "If an account exists for that email, you’ll receive a password reset link shortly.";
+}
+

--- a/apps/mobile/src/lib/deepLinks.ts
+++ b/apps/mobile/src/lib/deepLinks.ts
@@ -1,0 +1,27 @@
+export type ResetLinkContext = { token: string };
+
+function safeDecode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+export function parseResetLink(url: string): ResetLinkContext | null {
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+
+  const tokenParamMatch = trimmed.match(/[?&]token=([^&#]+)/i);
+  if (tokenParamMatch?.[1]) {
+    return { token: safeDecode(tokenParamMatch[1]) };
+  }
+
+  const pathMatch = trimmed.match(/\/reset-password\/([^/?#]+)/i);
+  if (pathMatch?.[1]) {
+    return { token: safeDecode(pathMatch[1]) };
+  }
+
+  return null;
+}
+

--- a/apps/mobile/src/lib/validation.ts
+++ b/apps/mobile/src/lib/validation.ts
@@ -1,0 +1,18 @@
+export function isValidEmail(email: string): boolean {
+  // Intentionally lightweight; server still validates.
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim());
+}
+
+export type PasswordValidation = {
+  ok: boolean;
+  message?: string;
+};
+
+export function validatePassword(password: string): PasswordValidation {
+  const trimmed = password.trim();
+  if (trimmed.length < 8) {
+    return { ok: false, message: "Password must be at least 8 characters." };
+  }
+  return { ok: true };
+}
+


### PR DESCRIPTION
Closes #369
Closes #370
Closes #371
Closes #372

## Summary
- Adds Expo mobile screens: sign-in, password reset request, password reset completion, and verification-pending state.
- Handles deep links for password reset tokens (documented in `apps/mobile/DEEP_LINKS.md`).
- Translates auth API errors into mobile-friendly messages and keeps password reset messaging privacy-safe.

## Testing
- `pnpm -C apps/mobile run typecheck`
- `pnpm -C apps/mobile run lint`