### PR TITLE
feat(types): AUTH_ERROR_CODES const, AuthSessionPayload, seed helpers, and mail capture

### DIFF
--- a/apps/api/src/__tests__/helpers/authSeeds.ts
+++ b/apps/api/src/__tests__/helpers/authSeeds.ts
@@ -1,0 +1,72 @@
+/**
+ * Auth seed helpers for local and CI testing (#391).
+ *
+ * Provides named test personas that map to realistic auth states.
+ * Use these in tests and smoke checks instead of ad-hoc inline credentials.
+ *
+ * Personas:
+ *   unverified  – registered but email not yet confirmed
+ *   verified    – registered and email confirmed, can log in
+ *   locked      – too many failed logins, account is locked
+ *   resetPending – password-reset token issued, not yet completed
+ */
+
+import type { RegisterRequest } from "@sidewalk/types";
+
+export type AuthPersona = "unverified" | "verified" | "locked" | "resetPending";
+
+export const SEED_CREDENTIALS: Record<AuthPersona, RegisterRequest> = {
+  unverified: { email: "unverified@sidewalk.test", password: "Test1234!" },
+  verified: { email: "verified@sidewalk.test", password: "Test1234!" },
+  locked: { email: "locked@sidewalk.test", password: "Test1234!" },
+  resetPending: { email: "reset-pending@sidewalk.test", password: "Test1234!" },
+};
+
+type RegisterFn = (body: RegisterRequest) => Promise<{ verifyToken?: string; accountId?: string }>;
+type VerifyFn = (token: string) => Promise<void>;
+type LoginFailFn = (email: string, times: number) => Promise<void>;
+type ResetRequestFn = (email: string) => Promise<{ resetToken?: string }>;
+
+export type SeedDeps = {
+  register: RegisterFn;
+  verify: VerifyFn;
+  loginFail: LoginFailFn;
+  resetRequest: ResetRequestFn;
+};
+
+/**
+ * Provision a single persona against the provided API helpers.
+ * Returns whatever tokens/IDs were issued so callers can drive further flows.
+ */
+export async function seedPersona(
+  persona: AuthPersona,
+  deps: SeedDeps
+): Promise<{ verifyToken?: string; resetToken?: string }> {
+  const creds = SEED_CREDENTIALS[persona];
+
+  if (persona === "unverified") {
+    const { verifyToken } = await deps.register(creds);
+    return { verifyToken };
+  }
+
+  if (persona === "verified") {
+    const { verifyToken } = await deps.register(creds);
+    if (verifyToken) await deps.verify(verifyToken);
+    return {};
+  }
+
+  if (persona === "locked") {
+    await deps.register(creds);
+    await deps.loginFail(creds.email, 5);
+    return {};
+  }
+
+  if (persona === "resetPending") {
+    const { verifyToken } = await deps.register(creds);
+    if (verifyToken) await deps.verify(verifyToken);
+    const { resetToken } = await deps.resetRequest(creds.email);
+    return { resetToken };
+  }
+
+  return {};
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,16 @@
+services:
+  # ── Local mail capture (#392) ─────────────────────────────────────────────
+  # Intercepts all outgoing SMTP and exposes a web UI for inspecting emails.
+  # Start: docker compose -f docker-compose.dev.yml up -d mailpit
+  # Open:  http://localhost:8025
+  # SMTP:  localhost:1025 (set MAIL_TRANSPORT=smtp MAIL_SMTP_HOST=localhost MAIL_SMTP_PORT=1025 in apps/api/.env)
+  mailpit:
+    image: axllent/mailpit:latest
+    ports:
+      - "1025:1025"   # SMTP
+      - "8025:8025"   # Web UI
+    environment:
+      MP_MAX_MESSAGES: 500
+      MP_SMTP_AUTH_ACCEPT_ANY: "true"
+      MP_SMTP_AUTH_ALLOW_INSECURE: "true"
+    restart: unless-stopped

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -74,7 +74,51 @@ export type AuthErrorCode =
   | "TOKEN_EXPIRED"
   | "RATE_LIMITED";
 
+/**
+ * Runtime-usable error code constants (#389).
+ * Use these instead of raw strings so API handlers, UI mappers, and tests all
+ * reference the same values and typos are caught at compile time.
+ *
+ * @example
+ *   if (err.code === AUTH_ERROR_CODES.INVALID_CREDENTIALS) { ... }
+ *   res.json({ code: AUTH_ERROR_CODES.EMAIL_TAKEN, message: "..." })
+ */
+export const AUTH_ERROR_CODES = {
+  VALIDATION_ERROR: "VALIDATION_ERROR",
+  EMAIL_TAKEN: "EMAIL_TAKEN",
+  INVALID_CREDENTIALS: "INVALID_CREDENTIALS",
+  ACCOUNT_UNVERIFIED: "ACCOUNT_UNVERIFIED",
+  ACCOUNT_LOCKED: "ACCOUNT_LOCKED",
+  INVALID_TOKEN: "INVALID_TOKEN",
+  SESSION_NOT_FOUND: "SESSION_NOT_FOUND",
+  TOKEN_EXPIRED: "TOKEN_EXPIRED",
+  RATE_LIMITED: "RATE_LIMITED",
+} as const satisfies Record<AuthErrorCode, AuthErrorCode>;
+
 export type AuthErrorResponse = {
   code: AuthErrorCode;
   message: string;
+};
+
+// ── Session payload (#390) ────────────────────────────────────────────────────
+
+/**
+ * The public account shape — safe to include in any client-facing payload.
+ * No password hashes, internal flags, or audit timestamps.
+ */
+export type AuthUser = {
+  id: string;
+  email: string;
+  verified: boolean;
+};
+
+/**
+ * Client-safe session payload: the account identity plus opaque tokens.
+ * All workspaces (web, mobile, internal services) should depend on this
+ * shape rather than ad-hoc inline types.
+ */
+export type AuthSessionPayload = SessionTokens & {
+  user: AuthUser;
+  /** ISO-8601 timestamp of when the session was created. */
+  issuedAt: string;
 };


### PR DESCRIPTION
## Summary

- **#389** – Add `AUTH_ERROR_CODES` as a `const` object to `packages/types`; satisfies `Record<AuthErrorCode, AuthErrorCode>` so it is type-safe at compile time and usable at runtime — API handlers and UI mappers can reference `AUTH_ERROR_CODES.INVALID_CREDENTIALS` instead of raw strings
- **#390** – Add `AuthUser` and `AuthSessionPayload` to `packages/types`; `AuthSessionPayload` extends `SessionTokens` with a typed `user` field and `issuedAt` timestamp — the single outward session shape for web, mobile, and internal services
- **#391** – Add `apps/api/src/__tests__/helpers/authSeeds.ts` with four named test personas (`unverified`, `verified`, `locked`, `resetPending`) and a `seedPersona` helper; contributors use these instead of ad-hoc credentials in tests and smoke checks
- **#392** – Add `docker-compose.dev.yml` with a Mailpit service on ports `1025` (SMTP) and `8025` (web UI); start with `docker compose -f docker-compose.dev.yml up -d mailpit` and set `MAIL_TRANSPORT=smtp MAIL_SMTP_HOST=localhost MAIL_SMTP_PORT=1025` in `apps/api/.env`

Closes #389
Closes #390
Closes #391
Closes #392