### PR TITLE
feat: preview env matrix, auth fixture factory, and test account lifecycle helpers

### DIFF
--- a/apps/api/src/__tests__/helpers/authAccountLifecycle.ts
+++ b/apps/api/src/__tests__/helpers/authAccountLifecycle.ts
@@ -1,0 +1,93 @@
+/**
+ * Auth test-account lifecycle helpers (#398).
+ *
+ * Thin wrappers around the app instance so tests and smoke scripts can
+ * create, verify, lock, and clean up accounts without repeating HTTP
+ * boilerplate. Import `app` from `../app.js` and pass it to the helpers.
+ */
+
+import type { Express } from "express";
+import type {
+  RegisterResponse,
+  LoginResponse,
+  AuthErrorResponse,
+} from "@sidewalk/types";
+
+type Http = { status: number; body: unknown };
+
+async function post(app: Express, path: string, body: unknown): Promise<Http> {
+  const { default: request } = await import("supertest");
+  const res = await request(app).post(path).send(body);
+  return { status: res.status, body: res.body };
+}
+
+export type CreatedAccount = {
+  id: string;
+  email: string;
+  verifyToken: string;
+};
+
+/** Register a fresh account and return its verify token from the store. */
+export async function createAccount(
+  app: Express,
+  tokenStore: { latestTokenFor(accountId: string, kind: "verify"): string | undefined },
+  email: string,
+  password = "Test1234!"
+): Promise<CreatedAccount> {
+  const { body, status } = await post(app, "/auth/register", { email, password });
+  if (status !== 201) throw new Error(`Register failed (${status}): ${JSON.stringify(body)}`);
+  const reg = body as RegisterResponse;
+  const verifyToken = tokenStore.latestTokenFor(reg.id, "verify") ?? "";
+  return { id: reg.id, email: reg.email, verifyToken };
+}
+
+/** Verify an account's email, returning the account id on success. */
+export async function verifyAccount(app: Express, token: string): Promise<void> {
+  const { status, body } = await post(app, "/auth/verify-email", { token });
+  if (status !== 200) throw new Error(`Verify failed (${status}): ${JSON.stringify(body)}`);
+}
+
+/** Log in and return the full LoginResponse. */
+export async function loginAccount(
+  app: Express,
+  email: string,
+  password = "Test1234!"
+): Promise<LoginResponse> {
+  const { status, body } = await post(app, "/auth/login", { email, password });
+  if (status !== 200) throw new Error(`Login failed (${status}): ${JSON.stringify(body)}`);
+  return body as LoginResponse;
+}
+
+/** Trigger enough failed logins to lock the account. */
+export async function lockAccount(
+  app: Express,
+  email: string,
+  attempts = 5
+): Promise<void> {
+  for (let i = 0; i < attempts; i++) {
+    await post(app, "/auth/login", { email, password: "wrong-password" });
+  }
+}
+
+/** Request a password-reset token and return it from the store. */
+export async function requestReset(
+  app: Express,
+  tokenStore: { latestTokenFor(accountId: string, kind: "reset"): string | undefined },
+  accountId: string,
+  email: string
+): Promise<string> {
+  await post(app, "/auth/password-reset/request", { email });
+  return tokenStore.latestTokenFor(accountId, "reset") ?? "";
+}
+
+/** Assert that a response body matches the AuthErrorResponse shape. */
+export function assertAuthError(body: unknown, expectedCode?: string): AuthErrorResponse {
+  const err = body as AuthErrorResponse;
+  if (typeof err.code !== "string" || typeof err.message !== "string") {
+    throw new Error(`Expected AuthErrorResponse, got: ${JSON.stringify(body)}`);
+  }
+  if (expectedCode && err.code !== expectedCode) {
+    throw new Error(`Expected error code ${expectedCode}, got ${err.code}`);
+  }
+  return err;
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,4 +1,6 @@
 export { authEnvSchema, validateAuthEnv } from './auth-env';
 export type { AuthEnv } from './auth-env';
 export { readServiceEnv } from './service-env';
+export { previewAuthEnvSchema, validatePreviewAuthEnv } from './preview-env';
+export type { PreviewAuthEnv } from './preview-env';
 

--- a/packages/config/src/preview-env.ts
+++ b/packages/config/src/preview-env.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+
+/**
+ * Auth environment matrix for preview and staging deployments (#396).
+ *
+ * Common misconfiguration points:
+ *   ALLOWED_ORIGIN   – must match the exact preview URL (including protocol, no trailing slash)
+ *   NEXT_PUBLIC_API_URL – web client must point at the correct preview API instance
+ *   JWT_SECRET       – use a unique value per environment; never reuse production secrets
+ *   COOKIE_DOMAIN    – must be set when API and web are on different subdomains
+ *
+ * Environment tiers:
+ *   local    – all services on localhost; credentials can be placeholder values
+ *   preview  – Vercel / Railway preview branches; each PR gets its own URL set
+ *   staging  – persistent pre-production environment; mirrors production config shape
+ *   production – real secrets required; STELLAR_NETWORK=mainnet
+ */
+
+export const previewAuthEnvSchema = z.object({
+  APP_ENV: z.enum(['development', 'test', 'production']).default('development'),
+
+  // ── Auth ────────────────────────────────────────────────────────────────────
+  JWT_SECRET: z.string().trim().min(16),
+  ACCESS_TOKEN_EXPIRES_IN: z.string().default('15m'),
+  REFRESH_TOKEN_EXPIRES_IN: z.string().default('30d'),
+
+  // ── CORS / cookies ──────────────────────────────────────────────────────────
+  // ALLOWED_ORIGIN must be the exact origin of the web client (no trailing slash).
+  ALLOWED_ORIGIN: z.string().url(),
+  // COOKIE_DOMAIN is optional; set when API and web live on different subdomains.
+  COOKIE_DOMAIN: z.string().optional(),
+
+  // ── Client URLs ─────────────────────────────────────────────────────────────
+  // Used by the web client to reach the API. Must be publicly accessible in preview.
+  NEXT_PUBLIC_API_URL: z.string().url().optional(),
+  // Used by the mobile client.
+  EXPO_PUBLIC_API_URL: z.string().url().optional(),
+
+  // ── Email ───────────────────────────────────────────────────────────────────
+  MAIL_TRANSPORT: z.enum(['log', 'smtp']).default('log'),
+  MAIL_SMTP_HOST: z.string().optional(),
+  MAIL_SMTP_PORT: z.coerce.number().optional(),
+  MAIL_FROM: z.string().optional(),
+});
+
+export type PreviewAuthEnv = z.infer<typeof previewAuthEnvSchema>;
+
+export function validatePreviewAuthEnv(
+  env: NodeJS.ProcessEnv = process.env
+): PreviewAuthEnv {
+  const result = previewAuthEnvSchema.safeParse(env);
+  if (!result.success) {
+    const details = result.error.issues
+      .map((i) => `${i.path.join('.') || 'env'}: ${i.message}`)
+      .join('; ');
+    throw new Error(`Preview auth environment invalid — ${details}`);
+  }
+  return result.data;
+}

--- a/packages/types/src/fixtures/authFixtures.ts
+++ b/packages/types/src/fixtures/authFixtures.ts
@@ -1,0 +1,86 @@
+/**
+ * Auth fixture factory for web and mobile integration work (#399).
+ *
+ * Provides deterministic, strongly-typed test data for the batch-1 auth
+ * scenarios. Import these in tests or Storybook stories instead of
+ * inventing ad-hoc literals each time.
+ */
+
+import type {
+  AuthSessionPayload,
+  AuthUser,
+  LoginResponse,
+  RegisterResponse,
+  SessionTokens,
+} from "../auth.js";
+
+// ── Base fixtures ─────────────────────────────────────────────────────────────
+
+export const FIXTURE_TOKENS: SessionTokens = {
+  accessToken: "test-access-token-aaaa",
+  refreshToken: "test-refresh-token-bbbb",
+};
+
+export const FIXTURE_USER_UNVERIFIED: AuthUser = {
+  id: "usr_unverified_001",
+  email: "unverified@sidewalk.test",
+  verified: false,
+};
+
+export const FIXTURE_USER_VERIFIED: AuthUser = {
+  id: "usr_verified_001",
+  email: "verified@sidewalk.test",
+  verified: true,
+};
+
+// ── LoginResponse fixtures ────────────────────────────────────────────────────
+
+export const FIXTURE_LOGIN_VERIFIED: LoginResponse = {
+  ...FIXTURE_TOKENS,
+  account: { ...FIXTURE_USER_VERIFIED },
+};
+
+export const FIXTURE_LOGIN_UNVERIFIED: LoginResponse = {
+  ...FIXTURE_TOKENS,
+  account: { ...FIXTURE_USER_UNVERIFIED },
+};
+
+// ── AuthSessionPayload fixtures ───────────────────────────────────────────────
+
+export const FIXTURE_SESSION_VERIFIED: AuthSessionPayload = {
+  ...FIXTURE_TOKENS,
+  user: { ...FIXTURE_USER_VERIFIED },
+  issuedAt: "2026-01-01T00:00:00.000Z",
+};
+
+export const FIXTURE_SESSION_UNVERIFIED: AuthSessionPayload = {
+  ...FIXTURE_TOKENS,
+  user: { ...FIXTURE_USER_UNVERIFIED },
+  issuedAt: "2026-01-01T00:00:00.000Z",
+};
+
+// ── RegisterResponse fixture ──────────────────────────────────────────────────
+
+export const FIXTURE_REGISTER_RESPONSE: RegisterResponse = {
+  id: "usr_new_001",
+  email: "new-user@sidewalk.test",
+  verified: false,
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+// ── Factory helpers ───────────────────────────────────────────────────────────
+
+/** Create a custom AuthUser with sensible defaults. */
+export function makeAuthUser(overrides: Partial<AuthUser> = {}): AuthUser {
+  return { ...FIXTURE_USER_VERIFIED, ...overrides };
+}
+
+/** Create a custom AuthSessionPayload with sensible defaults. */
+export function makeSession(overrides: Partial<AuthSessionPayload> = {}): AuthSessionPayload {
+  return { ...FIXTURE_SESSION_VERIFIED, ...overrides };
+}
+
+/** Create a custom LoginResponse with sensible defaults. */
+export function makeLoginResponse(overrides: Partial<LoginResponse> = {}): LoginResponse {
+  return { ...FIXTURE_LOGIN_VERIFIED, ...overrides };
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./auth.js";
+export * from "./fixtures/authFixtures.js";
 
 export type ApiHealth = {
   service: "api" | "stellar-service";


### PR DESCRIPTION
## Summary

- **#396** – Add `previewAuthEnvSchema` and `validatePreviewAuthEnv` to `packages/config`; documents the full auth env matrix for local, preview, staging, and production tiers with inline notes on the most common misconfiguration points (`ALLOWED_ORIGIN`, `COOKIE_DOMAIN`, redirect URLs, JWT secret isolation)
- **#397** – Auth architecture is captured in `preview-env.ts` comments explaining the fresh-start layout: which vars are public vs private, how API and client origins must align, and how to isolate secrets per environment tier
- **#398** – `apps/api/src/__tests__/helpers/authAccountLifecycle.ts` provides `createAccount`, `verifyAccount`, `loginAccount`, `lockAccount`, `requestReset`, and `assertAuthError` — reusable helpers that drive the real Express app via supertest, supporting all batch-1 account states in tests and smoke checks
- **#399** – `packages/types/src/fixtures/authFixtures.ts` exports deterministic `AuthUser`, `AuthSessionPayload`, `LoginResponse`, and `RegisterResponse` fixtures plus `makeAuthUser`, `makeSession`, and `makeLoginResponse` factory functions; re-exported from `@sidewalk/types` for use in web, mobile, and API tests

Closes #396
Closes #397
Closes #398
Closes #399