### PR TITLE
feat(mobile): biometric extension hook, auth analytics, full auth client, and verify deep links

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -19,7 +19,7 @@ import {
   memoryTokenStore,
   requestPasswordReset,
 } from "./src/lib/authClient";
-import { parseResetLink } from "./src/lib/deepLinks";
+import { parseResetLink, parseVerifyEmailLink } from "./src/lib/deepLinks";
 import {
   friendlyAuthMessage,
   privacySafeResetMessage,
@@ -126,6 +126,12 @@ export default function App() {
   useEffect(() => {
     function handleUrl(nextUrl: string | null | undefined) {
       if (!nextUrl) return;
+      // #384 – check verification link before reset so dedicated routes are preferred
+      const verify = parseVerifyEmailLink(nextUrl);
+      if (verify) {
+        setRoute({ name: "verificationPending", email: undefined });
+        return;
+      }
       const reset = parseResetLink(nextUrl);
       if (reset) setRoute({ name: "resetPassword", token: reset.token });
     }

--- a/apps/mobile/src/lib/authAnalytics.ts
+++ b/apps/mobile/src/lib/authAnalytics.ts
@@ -1,0 +1,43 @@
+/**
+ * Mobile auth analytics (#382).
+ *
+ * Emits named events for key auth funnel actions. Payloads are intentionally
+ * minimal — no credentials, raw tokens, or unnecessary personal data.
+ *
+ * Drop-in replacement: swap `defaultSink` for your analytics provider
+ * (Segment, PostHog, Amplitude, etc.) without touching call sites.
+ */
+
+export type AuthAnalyticsEvent =
+  | { name: "auth_login_attempted" }
+  | { name: "auth_login_succeeded" }
+  | { name: "auth_login_failed"; reason: string }
+  | { name: "auth_logout" }
+  | { name: "auth_register_attempted" }
+  | { name: "auth_register_succeeded" }
+  | { name: "auth_register_failed"; reason: string }
+  | { name: "auth_reset_requested" }
+  | { name: "auth_reset_completed" }
+  | { name: "auth_verify_email_opened" }
+  | { name: "auth_deep_link_opened"; linkType: "reset" | "verify" };
+
+export type AnalyticsSink = (event: AuthAnalyticsEvent) => void;
+
+let activeSink: AnalyticsSink = (event) => {
+  if (__DEV__) {
+    console.log("[auth:analytics]", event.name, event);
+  }
+};
+
+/** Replace the default sink with your analytics provider. */
+export function setAnalyticsSink(sink: AnalyticsSink): void {
+  activeSink = sink;
+}
+
+export function trackAuthEvent(event: AuthAnalyticsEvent): void {
+  try {
+    activeSink(event);
+  } catch {
+    // Analytics must never crash the auth flow.
+  }
+}

--- a/apps/mobile/src/lib/authClient.ts
+++ b/apps/mobile/src/lib/authClient.ts
@@ -7,11 +7,16 @@ import type {
   AuthErrorResponse,
   LoginRequest,
   LoginResponse,
+  LogoutResponse,
   PasswordResetCompleteRequest,
   PasswordResetCompleteResponse,
   PasswordResetRequestRequest,
   PasswordResetRequestResponse,
+  RegisterRequest,
+  RegisterResponse,
   SessionTokens,
+  VerifyEmailRequest,
+  VerifyEmailResponse,
 } from "@sidewalk/types";
 
 const UNKNOWN_ERROR: AuthErrorResponse = {
@@ -121,5 +126,36 @@ export function completePasswordReset(
     "/auth/password-reset/complete",
     body
   );
+}
+
+// #383 – complete the mobile auth client surface to mirror API contracts
+
+export function register(
+  body: RegisterRequest
+): Promise<AuthResult<RegisterResponse>> {
+  return authRequest<RegisterResponse, RegisterRequest>("/auth/register", body);
+}
+
+export function verifyEmail(
+  body: VerifyEmailRequest
+): Promise<AuthResult<VerifyEmailResponse>> {
+  return authRequest<VerifyEmailResponse, VerifyEmailRequest>("/auth/verify-email", body);
+}
+
+export async function logout(accessToken: string): Promise<AuthResult<LogoutResponse>> {
+  try {
+    const res = await fetch(endpoint("/auth/logout"), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({}),
+    });
+    if (!res.ok) return { ok: false, error: await parseAuthError(res) };
+    return { ok: true, data: (await res.json()) as LogoutResponse };
+  } catch {
+    return { ok: false, error: UNKNOWN_ERROR };
+  }
 }
 

--- a/apps/mobile/src/lib/biometricExtension.ts
+++ b/apps/mobile/src/lib/biometricExtension.ts
@@ -1,0 +1,47 @@
+/**
+ * Architecture hook for future biometric re-entry (#381).
+ *
+ * This module defines WHERE biometric unlock plugs into the mobile auth
+ * lifecycle. No biometric logic ships yet — the interface is the contract.
+ *
+ * Extension path:
+ *   1. Install `expo-local-authentication`.
+ *   2. Implement `BiometricProvider` using `LocalAuthentication.authenticateAsync`.
+ *   3. Call `setBiometricProvider(provider)` at app startup.
+ *   4. Call `promptBiometricReentry()` when re-auth is needed (e.g. after
+ *      app foreground, before sensitive operations).
+ *
+ * Current session bootstrap and storage decisions (see secureStorage.ts) are
+ * designed so biometric unlock can gate token retrieval without changing the
+ * storage interface.
+ */
+
+export type BiometricResult =
+  | { success: true }
+  | { success: false; reason: "cancelled" | "failed" | "unavailable" };
+
+export interface BiometricProvider {
+  isAvailable(): Promise<boolean>;
+  prompt(reason: string): Promise<BiometricResult>;
+}
+
+let provider: BiometricProvider | null = null;
+
+/** Register the biometric implementation at app startup. */
+export function setBiometricProvider(p: BiometricProvider): void {
+  provider = p;
+}
+
+/**
+ * Prompt for biometric re-entry.
+ * Returns `{ success: false, reason: "unavailable" }` when no provider is
+ * registered — callers must handle this gracefully (fall back to password).
+ */
+export async function promptBiometricReentry(
+  reason = "Confirm your identity to continue"
+): Promise<BiometricResult> {
+  if (!provider) return { success: false, reason: "unavailable" };
+  const available = await provider.isAvailable();
+  if (!available) return { success: false, reason: "unavailable" };
+  return provider.prompt(reason);
+}

--- a/apps/mobile/src/lib/deepLinks.ts
+++ b/apps/mobile/src/lib/deepLinks.ts
@@ -1,4 +1,5 @@
 export type ResetLinkContext = { token: string };
+export type VerifyEmailLinkContext = { token: string };
 
 function safeDecode(value: string): string {
   try {
@@ -18,6 +19,33 @@ export function parseResetLink(url: string): ResetLinkContext | null {
   }
 
   const pathMatch = trimmed.match(/\/reset-password\/([^/?#]+)/i);
+  if (pathMatch?.[1]) {
+    return { token: safeDecode(pathMatch[1]) };
+  }
+
+  return null;
+}
+
+/**
+ * #384 – Parse a verification deep link.
+ *
+ * Supported formats:
+ *   sidewalk://verify-email?token=<TOKEN>
+ *   sidewalk://auth/verify-email?token=<TOKEN>
+ *   sidewalk://verify-email/<TOKEN>
+ */
+export function parseVerifyEmailLink(url: string): VerifyEmailLinkContext | null {
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+
+  if (!/verify/i.test(trimmed)) return null;
+
+  const tokenParamMatch = trimmed.match(/[?&]token=([^&#]+)/i);
+  if (tokenParamMatch?.[1]) {
+    return { token: safeDecode(tokenParamMatch[1]) };
+  }
+
+  const pathMatch = trimmed.match(/\/verify-email\/([^/?#]+)/i);
   if (pathMatch?.[1]) {
     return { token: safeDecode(pathMatch[1]) };
   }


### PR DESCRIPTION
## Summary

- **#381** – Add `apps/mobile/src/lib/biometricExtension.ts`; defines `BiometricProvider` interface and `promptBiometricReentry` function; the extension point hooks into session bootstrap/storage without requiring changes to the storage layer; designed for `expo-local-authentication` without shipping any premature biometric security
- **#382** – Add `apps/mobile/src/lib/authAnalytics.ts`; defines `AuthAnalyticsEvent` union covering login, logout, register, reset, verify, and deep-link events; payloads are intentionally credential-free; `setAnalyticsSink` lets the app layer swap in Segment / PostHog / Amplitude without touching call sites
- **#383** – Extend `apps/mobile/src/lib/authClient.ts` with `register`, `verifyEmail`, and `logout` to complete the mobile API surface; all functions are typed against `@sidewalk/types` and follow the same `AuthResult<T>` pattern as the existing client
- **#384** – Add `parseVerifyEmailLink` to `deepLinks.ts` supporting `sidewalk://verify-email?token=`, `sidewalk://auth/verify-email?token=`, and `sidewalk://verify-email/<TOKEN>` formats; wire it into the `App` deep-link handler so incoming verification links route to the `verificationPending` screen

Closes #381
Closes #382
Closes #383
Closes #384