### PR TITLE
Auth contributor runway: dev-only shortcuts, safe structured events, and route-surface docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The initial scaffold intentionally keeps secrets and third-party dependencies mi
 This repo is being prepared for public contributors. Keep changes scoped, document new environment variables, and prefer shared contracts in `packages/types` when multiple apps need the same shape.
 
 For auth UI conventions in the web workspace, see `apps/web/AUTH_CONTRIBUTING.md`.
+For auth backend routes, payloads, and test harness notes, see `apps/api/AUTH_API.md`.
 
 ## License
 

--- a/apps/api/AUTH_API.md
+++ b/apps/api/AUTH_API.md
@@ -1,0 +1,56 @@
+# Auth API Surface
+
+Base path: `/auth`
+
+## Endpoints
+
+- `POST /auth/register`
+  - Body: `{ "email": "user@example.com", "password": "password123" }`
+  - Success: `201 { id, email, verified, createdAt }`
+  - Errors: `400 VALIDATION_ERROR`, `409 EMAIL_TAKEN`
+
+- `POST /auth/login`
+  - Body: `{ "email": "user@example.com", "password": "password123" }`
+  - Success: `200 { accessToken, refreshToken, account }`
+  - Errors: `400 VALIDATION_ERROR`, `401 INVALID_CREDENTIALS`, `403 ACCOUNT_LOCKED`
+
+- `POST /auth/refresh`
+  - Body: `{ "refreshToken": "..." }`
+  - Success: `200 { accessToken, refreshToken }`
+  - Errors: `400 VALIDATION_ERROR`, `401 INVALID_TOKEN`
+
+- `POST /auth/logout`
+  - Header: `Authorization: Bearer <accessToken>`
+  - Success: `200 { message }`
+
+- `POST /auth/logout/all`
+  - Header: `Authorization: Bearer <accessToken>`
+  - Success: `200 { message }`
+
+- `POST /auth/verify-email`
+  - Body: `{ "token": "..." }`
+  - Success: `200 { message }`
+  - Errors: `400 VALIDATION_ERROR|INVALID_TOKEN`
+
+- `POST /auth/password-reset/request`
+  - Body: `{ "email": "user@example.com" }`
+  - Success: `200` privacy-safe message for both known/unknown accounts
+
+- `POST /auth/password-reset/complete`
+  - Body: `{ "token": "...", "password": "newpass123" }`
+  - Success: `200 { message }`
+  - Errors: `400 VALIDATION_ERROR|INVALID_TOKEN`
+
+## Dev-only shortcut
+
+- `POST /auth/dev/seed-user`
+  - Available only when both are true:
+  - `APP_ENV=development`
+  - `ENABLE_DEV_AUTH_SHORTCUTS=true`
+  - Returns `404` in all other environments.
+  - Use only for local integration setup, not real auth behavior testing.
+
+## Auth Integration Harness
+
+Use `apps/api/src/__tests__/auth.test.ts` as the integration harness.
+It already covers registration and login and can be extended for new endpoint flows.

--- a/apps/api/src/__tests__/auth.test.ts
+++ b/apps/api/src/__tests__/auth.test.ts
@@ -372,6 +372,17 @@ describe("POST /auth/password-reset/complete", () => {
   });
 });
 
+describe("POST /auth/dev/seed-user", () => {
+  it("is blocked outside development shortcut mode", async () => {
+    const res = await request(app)
+      .post("/auth/dev/seed-user")
+      .send({ email: "devseed@example.com", password: "password123" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe("NOT_FOUND");
+  });
+});
+
 // ── rate limiting ─────────────────────────────────────────────────────────────
 
 import { makeRateLimiter } from "../middleware/authRateLimit.js";

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -31,12 +31,14 @@ import {
   verifyResendRateLimit
 } from "./middleware/authRateLimit.js";
 import { recordAuthEvent, getMetrics } from "./services/authMetrics.js";
+import { authAuditLog } from "./services/authAuditLog.js";
 
 const env = readServiceEnv(
   "api",
   z.object({
     PORT: z.coerce.number().default(4000),
     APP_ENV: z.enum(["development", "test", "production"]).default("development"),
+    ENABLE_DEV_AUTH_SHORTCUTS: z.enum(["true", "false"]).default("false"),
     JWT_SECRET: z.string().min(8).default("replace-me"),
     ALLOWED_ORIGIN: z.string().url().default("http://localhost:3000")
   })
@@ -97,6 +99,7 @@ app.post("/auth/register", registerRateLimit, async (req, res) => {
   const t0 = Date.now();
   const parsed = registerSchema.safeParse(req.body);
   if (!parsed.success) {
+    authAuditLog(req, "register", "failure", { code: "VALIDATION_ERROR" });
     recordAuthEvent("register", "failure", Date.now() - t0);
     const err: AuthErrorResponse = { code: "VALIDATION_ERROR", message: parsed.error.issues[0].message };
     res.status(400).json(err);
@@ -105,6 +108,7 @@ app.post("/auth/register", registerRateLimit, async (req, res) => {
 
   const { email, password } = parsed.data;
   if ([...accounts.values()].some((a) => a.email === email)) {
+    authAuditLog(req, "register", "failure", { code: "EMAIL_TAKEN", email });
     recordAuthEvent("register", "failure", Date.now() - t0);
     const err: AuthErrorResponse = { code: "EMAIL_TAKEN", message: "Email already registered." };
     res.status(409).json(err);
@@ -129,6 +133,7 @@ app.post("/auth/register", registerRateLimit, async (req, res) => {
   }
 
   recordAuthEvent("register", "success", Date.now() - t0);
+  authAuditLog(req, "register", "success", { accountId: account.id, email });
   const pub = toPublic(account);
   const body: RegisterResponse = { id: pub.id, email: pub.email, verified: pub.verified, createdAt: pub.createdAt.toISOString() };
   res.status(201).json(body);
@@ -140,6 +145,7 @@ app.post("/auth/verify-email", verifyResendRateLimit, (req, res) => {
   const t0 = Date.now();
   const parsed = verifyEmailSchema.safeParse(req.body);
   if (!parsed.success) {
+    authAuditLog(req, "verify_email", "failure", { code: "VALIDATION_ERROR" });
     recordAuthEvent("verify_email", "failure", Date.now() - t0);
     const err: AuthErrorResponse = { code: "VALIDATION_ERROR", message: parsed.error.issues[0].message };
     res.status(400).json(err);
@@ -148,6 +154,7 @@ app.post("/auth/verify-email", verifyResendRateLimit, (req, res) => {
 
   const accountId = tokenStore.consume(parsed.data.token, "verify");
   if (!accountId) {
+    authAuditLog(req, "verify_email", "failure", { code: "INVALID_TOKEN" });
     recordAuthEvent("verify_email", "failure", Date.now() - t0);
     const err: AuthErrorResponse = { code: "INVALID_TOKEN", message: "Verification token is invalid or expired." };
     res.status(400).json(err);
@@ -156,6 +163,7 @@ app.post("/auth/verify-email", verifyResendRateLimit, (req, res) => {
 
   const account = accounts.get(accountId);
   if (!account) {
+    authAuditLog(req, "verify_email", "failure", { code: "INVALID_TOKEN" });
     recordAuthEvent("verify_email", "failure", Date.now() - t0);
     const err: AuthErrorResponse = { code: "INVALID_TOKEN", message: "Verification token is invalid or expired." };
     res.status(400).json(err);
@@ -165,6 +173,7 @@ app.post("/auth/verify-email", verifyResendRateLimit, (req, res) => {
   account.verified = true;
   account.updatedAt = new Date();
   recordAuthEvent("verify_email", "success", Date.now() - t0);
+  authAuditLog(req, "verify_email", "success", { accountId: account.id });
   const body: VerifyEmailResponse = { message: "Email verified." };
   res.status(200).json(body);
 });
@@ -175,6 +184,7 @@ app.post("/auth/login", loginRateLimit, async (req, res) => {
   const t0 = Date.now();
   const parsed = loginSchema.safeParse(req.body);
   if (!parsed.success) {
+    authAuditLog(req, "login", "failure", { code: "VALIDATION_ERROR" });
     recordAuthEvent("login", "failure", Date.now() - t0);
     const err: AuthErrorResponse = { code: "VALIDATION_ERROR", message: parsed.error.issues[0].message };
     res.status(400).json(err);
@@ -187,6 +197,7 @@ app.post("/auth/login", loginRateLimit, async (req, res) => {
 
   // Check lockout before verifying password to avoid timing leaks
   if (account && lockoutService.isLocked(account.id)) {
+    authAuditLog(req, "login", "failure", { code: "ACCOUNT_LOCKED", email });
     suspiciousLoginLogger.record({ timestamp: new Date().toISOString(), email, ip, reason: "ACCOUNT_LOCKED" });
     recordAuthEvent("login", "failure", Date.now() - t0);
     const err: AuthErrorResponse = { code: "ACCOUNT_LOCKED", message: "Account temporarily locked. Please try again later." };
@@ -208,6 +219,7 @@ app.post("/auth/login", loginRateLimit, async (req, res) => {
   lockoutService.recordSuccess(account.id);
   const session = sessionStore.create(account.id);
   recordAuthEvent("login", "success", Date.now() - t0);
+  authAuditLog(req, "login", "success", { accountId: account.id, email });
   const body: LoginResponse = {
     accessToken: session.sessionId,
     refreshToken: session.refreshToken,
@@ -245,6 +257,7 @@ app.post("/auth/password-reset/request", resetRateLimit, (req, res) => {
   const t0 = Date.now();
   const parsed = resetRequestSchema.safeParse(req.body);
   if (!parsed.success) {
+    authAuditLog(req, "password_reset_request", "failure", { code: "VALIDATION_ERROR" });
     recordAuthEvent("password_reset", "failure", Date.now() - t0);
     const err: AuthErrorResponse = { code: "VALIDATION_ERROR", message: parsed.error.issues[0].message };
     res.status(400).json(err);
@@ -260,6 +273,7 @@ app.post("/auth/password-reset/request", resetRateLimit, (req, res) => {
   }
 
   recordAuthEvent("password_reset", "success", Date.now() - t0);
+  authAuditLog(req, "password_reset_request", "success", { email: parsed.data.email });
   const body: PasswordResetRequestResponse = {
     message: "If that email is registered you will receive a reset link shortly."
   };
@@ -271,6 +285,7 @@ app.post("/auth/password-reset/request", resetRateLimit, (req, res) => {
 app.post("/auth/password-reset/complete", resetRateLimit, async (req, res) => {
   const parsed = resetCompleteSchema.safeParse(req.body);
   if (!parsed.success) {
+    authAuditLog(req, "password_reset_complete", "failure", { code: "VALIDATION_ERROR" });
     const err: AuthErrorResponse = { code: "VALIDATION_ERROR", message: parsed.error.issues[0].message };
     res.status(400).json(err);
     return;
@@ -278,6 +293,7 @@ app.post("/auth/password-reset/complete", resetRateLimit, async (req, res) => {
 
   const accountId = tokenStore.consume(parsed.data.token, "reset");
   if (!accountId) {
+    authAuditLog(req, "password_reset_complete", "failure", { code: "INVALID_TOKEN" });
     const err: AuthErrorResponse = { code: "INVALID_TOKEN", message: "Reset token is invalid or expired." };
     res.status(400).json(err);
     return;
@@ -285,6 +301,7 @@ app.post("/auth/password-reset/complete", resetRateLimit, async (req, res) => {
 
   const account = accounts.get(accountId);
   if (!account) {
+    authAuditLog(req, "password_reset_complete", "failure", { code: "INVALID_TOKEN" });
     const err: AuthErrorResponse = { code: "INVALID_TOKEN", message: "Reset token is invalid or expired." };
     res.status(400).json(err);
     return;
@@ -297,7 +314,38 @@ app.post("/auth/password-reset/complete", resetRateLimit, async (req, res) => {
   sessionStore.revokeAll(accountId);
 
   const body: PasswordResetCompleteResponse = { message: "Password updated. Please log in again." };
+  authAuditLog(req, "password_reset_complete", "success", { accountId: account.id });
   res.status(200).json(body);
+});
+
+// Development-only shortcut for local auth fixture seeding.
+app.post("/auth/dev/seed-user", async (req, res) => {
+  if (env.APP_ENV !== "development" || env.ENABLE_DEV_AUTH_SHORTCUTS !== "true") {
+    const err: AuthErrorResponse = { code: "NOT_FOUND", message: "Route not found." };
+    res.status(404).json(err);
+    return;
+  }
+
+  const parsed = registerSchema.safeParse(req.body);
+  if (!parsed.success) {
+    const err: AuthErrorResponse = { code: "VALIDATION_ERROR", message: parsed.error.issues[0].message };
+    res.status(400).json(err);
+    return;
+  }
+
+  const { email, password } = parsed.data;
+  const now = new Date();
+  const account: Account = {
+    id: String(nextId++),
+    email,
+    passwordHash: await hashPassword(password),
+    verified: true,
+    createdAt: now,
+    updatedAt: now
+  };
+  accounts.set(account.id, account);
+  authAuditLog(req, "register", "success", { accountId: account.id, shortcut: true });
+  res.status(201).json({ id: account.id, email: account.email, verified: true });
 });
 
 // ── Logout (single device) ────────────────────────────────────────────────────
@@ -352,3 +400,4 @@ app.get("/auth/metrics", (_req, res) => {
 
 export { env };
 export { resetMetrics } from "./services/authMetrics.js";
+    authAuditLog(req, "login", "failure", { code: "INVALID_CREDENTIALS", email });

--- a/apps/api/src/services/authAuditLog.ts
+++ b/apps/api/src/services/authAuditLog.ts
@@ -1,0 +1,27 @@
+import type { Request } from "express";
+
+export type AuthAction =
+  | "register"
+  | "login"
+  | "logout"
+  | "verify_email"
+  | "password_reset_request"
+  | "password_reset_complete";
+
+export function authAuditLog(
+  req: Request,
+  action: AuthAction,
+  outcome: "success" | "failure",
+  metadata: Record<string, unknown> = {}
+): void {
+  const payload = {
+    event: "auth.audit",
+    action,
+    outcome,
+    requestId: req.header("x-request-id") ?? "none",
+    ip: req.ip ?? "unknown",
+    timestamp: new Date().toISOString(),
+    ...metadata
+  };
+  console.info(JSON.stringify(payload));
+}


### PR DESCRIPTION
## Summary
This PR delivers a compact auth milestone support pass with minimal code changes and clear contributor guidance.

## What changed
- Added a development-only auth seed shortcut endpoint:
  - POST /auth/dev/seed-user
  - hard-gated behind APP_ENV=development and ENABLE_DEV_AUTH_SHORTCUTS=true
  - returns 404 when gate is not satisfied
- Added structured auth audit logging helper with safe fields only (no passwords/tokens):
  - request correlation via x-request-id
  - action/outcome/IP/timestamp metadata
- Wired audit logs into registration, login, verification, and reset flows.
- Added contributor-facing auth API docs:
  - apps/api/AUTH_API.md
  - linked from root README
- Added guardrail test to verify dev shortcut is blocked by default.

## Validation
- Local test command could not be executed in this environment because pnpm is not available in PATH.

Closes #337
Closes #338
Closes #339
Closes #340
