### PR TITLE
Auth resilience starter pass: feature gates, password-policy ADR, and refresh-reuse signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ This repo is being prepared for public contributors. Keep changes scoped, docume
 
 For auth UI conventions in the web workspace, see `apps/web/AUTH_CONTRIBUTING.md`.
 For auth backend routes, payloads, and test harness notes, see `apps/api/AUTH_API.md`.
+For auth policy and feature-flag decisions, see `apps/api/AUTH_DECISIONS.md`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The initial scaffold intentionally keeps secrets and third-party dependencies mi
 This repo is being prepared for public contributors. Keep changes scoped, document new environment variables, and prefer shared contracts in `packages/types` when multiple apps need the same shape.
 
 For auth UI conventions in the web workspace, see `apps/web/AUTH_CONTRIBUTING.md`.
+For auth backend routes, payloads, and test harness notes, see `apps/api/AUTH_API.md`.
 
 ## License
 

--- a/apps/api/AUTH_API.md
+++ b/apps/api/AUTH_API.md
@@ -1,0 +1,56 @@
+# Auth API Surface
+
+Base path: `/auth`
+
+## Endpoints
+
+- `POST /auth/register`
+  - Body: `{ "email": "user@example.com", "password": "password123" }`
+  - Success: `201 { id, email, verified, createdAt }`
+  - Errors: `400 VALIDATION_ERROR`, `409 EMAIL_TAKEN`
+
+- `POST /auth/login`
+  - Body: `{ "email": "user@example.com", "password": "password123" }`
+  - Success: `200 { accessToken, refreshToken, account }`
+  - Errors: `400 VALIDATION_ERROR`, `401 INVALID_CREDENTIALS`, `403 ACCOUNT_LOCKED`
+
+- `POST /auth/refresh`
+  - Body: `{ "refreshToken": "..." }`
+  - Success: `200 { accessToken, refreshToken }`
+  - Errors: `400 VALIDATION_ERROR`, `401 INVALID_TOKEN`
+
+- `POST /auth/logout`
+  - Header: `Authorization: Bearer <accessToken>`
+  - Success: `200 { message }`
+
+- `POST /auth/logout/all`
+  - Header: `Authorization: Bearer <accessToken>`
+  - Success: `200 { message }`
+
+- `POST /auth/verify-email`
+  - Body: `{ "token": "..." }`
+  - Success: `200 { message }`
+  - Errors: `400 VALIDATION_ERROR|INVALID_TOKEN`
+
+- `POST /auth/password-reset/request`
+  - Body: `{ "email": "user@example.com" }`
+  - Success: `200` privacy-safe message for both known/unknown accounts
+
+- `POST /auth/password-reset/complete`
+  - Body: `{ "token": "...", "password": "newpass123" }`
+  - Success: `200 { message }`
+  - Errors: `400 VALIDATION_ERROR|INVALID_TOKEN`
+
+## Dev-only shortcut
+
+- `POST /auth/dev/seed-user`
+  - Available only when both are true:
+  - `APP_ENV=development`
+  - `ENABLE_DEV_AUTH_SHORTCUTS=true`
+  - Returns `404` in all other environments.
+  - Use only for local integration setup, not real auth behavior testing.
+
+## Auth Integration Harness
+
+Use `apps/api/src/__tests__/auth.test.ts` as the integration harness.
+It already covers registration and login and can be extended for new endpoint flows.

--- a/apps/api/AUTH_DECISIONS.md
+++ b/apps/api/AUTH_DECISIONS.md
@@ -1,0 +1,37 @@
+# Auth Decision Record (MVP Starter)
+
+## Password policy
+
+- Minimum length: 8 characters (matches API validation).
+- No complexity regex in MVP to reduce signup friction during hackathons.
+- Weak/common-password blocking is deferred to a follow-up once persistent user storage is introduced.
+- Reset policy: password reset completion revokes all sessions.
+
+Tradeoff:
+- Faster contributor onboarding now, stronger password quality controls planned as a next hardening pass.
+
+## Feature-flag rollout baseline
+
+Lightweight environment flags in API:
+- `ENABLE_DEV_AUTH_SHORTCUTS` for local-only seed helpers.
+- `ENABLE_AUTH_SESSION_LIST` for gradual rollout of session-listing behavior.
+
+Guidance:
+- New auth capabilities should default OFF.
+- Route handlers must return `404` when a flag is disabled.
+
+## Brute-force defensive posture
+
+Current multi-signal baseline:
+- Account-level lockout via failed-login counters.
+- Route-level rate limiting for auth endpoints.
+- Suspicious login logging with origin/IP context.
+
+False-positive minimization:
+- Lockout is time-boxed and automatically expires.
+- Unknown-account responses remain generic.
+
+## Refresh reuse signal
+
+- Reused/rotated refresh tokens are tracked as suspicious reuse signals.
+- Reuse emits a safe structured log event (`REFRESH_REUSE_DETECTED`) for review.

--- a/apps/api/src/__tests__/auth.test.ts
+++ b/apps/api/src/__tests__/auth.test.ts
@@ -383,6 +383,21 @@ describe("POST /auth/dev/seed-user", () => {
   });
 });
 
+describe("refresh-token reuse signal", () => {
+  it("treats rotated refresh reuse as invalid token", async () => {
+    await request(app).post("/auth/register").send({ email: "reuse@example.com", password: "password123" });
+    const login = await request(app).post("/auth/login").send({ email: "reuse@example.com", password: "password123" });
+    const firstRefresh = login.body.refreshToken;
+
+    const rotate = await request(app).post("/auth/refresh").send({ refreshToken: firstRefresh });
+    expect(rotate.status).toBe(200);
+
+    const replay = await request(app).post("/auth/refresh").send({ refreshToken: firstRefresh });
+    expect(replay.status).toBe(401);
+    expect(replay.body.code).toBe("INVALID_TOKEN");
+  });
+});
+
 // ── rate limiting ─────────────────────────────────────────────────────────────
 
 import { makeRateLimiter } from "../middleware/authRateLimit.js";

--- a/apps/api/src/__tests__/auth.test.ts
+++ b/apps/api/src/__tests__/auth.test.ts
@@ -372,6 +372,17 @@ describe("POST /auth/password-reset/complete", () => {
   });
 });
 
+describe("POST /auth/dev/seed-user", () => {
+  it("is blocked outside development shortcut mode", async () => {
+    const res = await request(app)
+      .post("/auth/dev/seed-user")
+      .send({ email: "devseed@example.com", password: "password123" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe("NOT_FOUND");
+  });
+});
+
 // ── rate limiting ─────────────────────────────────────────────────────────────
 
 import { makeRateLimiter } from "../middleware/authRateLimit.js";

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -39,6 +39,7 @@ const env = readServiceEnv(
     PORT: z.coerce.number().default(4000),
     APP_ENV: z.enum(["development", "test", "production"]).default("development"),
     ENABLE_DEV_AUTH_SHORTCUTS: z.enum(["true", "false"]).default("false"),
+    ENABLE_AUTH_SESSION_LIST: z.enum(["true", "false"]).default("false"),
     JWT_SECRET: z.string().min(8).default("replace-me"),
     ALLOWED_ORIGIN: z.string().url().default("http://localhost:3000")
   })
@@ -240,6 +241,10 @@ app.post("/auth/refresh", (req, res) => {
 
   const existing = sessionStore.getByRefreshToken(parsed.data.refreshToken);
   if (!existing) {
+    const suspectedReuse = sessionStore.wasRefreshTokenSeen(parsed.data.refreshToken);
+    if (suspectedReuse) {
+      authAuditLog(req, "login", "failure", { code: "REFRESH_REUSE_DETECTED" });
+    }
     const err: AuthErrorResponse = { code: "INVALID_TOKEN", message: "Refresh token is invalid or already used." };
     res.status(401).json(err);
     return;
@@ -398,6 +403,26 @@ app.get("/auth/metrics", (_req, res) => {
   res.json(getMetrics());
 });
 
+app.get("/auth/sessions", (req, res) => {
+  if (env.ENABLE_AUTH_SESSION_LIST !== "true") {
+    const err: AuthErrorResponse = { code: "NOT_FOUND", message: "Route not found." };
+    res.status(404).json(err);
+    return;
+  }
+  const token = bearerToken(req.headers.authorization);
+  if (!token) {
+    const err: AuthErrorResponse = { code: "INVALID_TOKEN", message: "Missing or malformed Authorization header." };
+    res.status(401).json(err);
+    return;
+  }
+  const session = sessionStore.getBySessionId(token);
+  if (!session) {
+    const err: AuthErrorResponse = { code: "SESSION_NOT_FOUND", message: "Session not found or already revoked." };
+    res.status(404).json(err);
+    return;
+  }
+  res.status(200).json([{ sessionId: session.sessionId, createdAt: session.createdAt.toISOString() }]);
+});
+
 export { env };
 export { resetMetrics } from "./services/authMetrics.js";
-    authAuditLog(req, "login", "failure", { code: "INVALID_CREDENTIALS", email });

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -31,12 +31,14 @@ import {
   verifyResendRateLimit
 } from "./middleware/authRateLimit.js";
 import { recordAuthEvent, getMetrics } from "./services/authMetrics.js";
+import { authAuditLog } from "./services/authAuditLog.js";
 
 const env = readServiceEnv(
   "api",
   z.object({
     PORT: z.coerce.number().default(4000),
     APP_ENV: z.enum(["development", "test", "production"]).default("development"),
+    ENABLE_DEV_AUTH_SHORTCUTS: z.enum(["true", "false"]).default("false"),
     JWT_SECRET: z.string().min(8).default("replace-me"),
     ALLOWED_ORIGIN: z.string().url().default("http://localhost:3000")
   })
@@ -97,6 +99,7 @@ app.post("/auth/register", registerRateLimit, async (req, res) => {
   const t0 = Date.now();
   const parsed = registerSchema.safeParse(req.body);
   if (!parsed.success) {
+    authAuditLog(req, "register", "failure", { code: "VALIDATION_ERROR" });
     recordAuthEvent("register", "failure", Date.now() - t0);
     const err: AuthErrorResponse = { code: "VALIDATION_ERROR", message: parsed.error.issues[0].message };
     res.status(400).json(err);
@@ -105,6 +108,7 @@ app.post("/auth/register", registerRateLimit, async (req, res) => {
 
   const { email, password } = parsed.data;
   if ([...accounts.values()].some((a) => a.email === email)) {
+    authAuditLog(req, "register", "failure", { code: "EMAIL_TAKEN", email });
     recordAuthEvent("register", "failure", Date.now() - t0);
     const err: AuthErrorResponse = { code: "EMAIL_TAKEN", message: "Email already registered." };
     res.status(409).json(err);
@@ -129,6 +133,7 @@ app.post("/auth/register", registerRateLimit, async (req, res) => {
   }
 
   recordAuthEvent("register", "success", Date.now() - t0);
+  authAuditLog(req, "register", "success", { accountId: account.id, email });
   const pub = toPublic(account);
   const body: RegisterResponse = { id: pub.id, email: pub.email, verified: pub.verified, createdAt: pub.createdAt.toISOString() };
   res.status(201).json(body);
@@ -140,6 +145,7 @@ app.post("/auth/verify-email", verifyResendRateLimit, (req, res) => {
   const t0 = Date.now();
   const parsed = verifyEmailSchema.safeParse(req.body);
   if (!parsed.success) {
+    authAuditLog(req, "verify_email", "failure", { code: "VALIDATION_ERROR" });
     recordAuthEvent("verify_email", "failure", Date.now() - t0);
     const err: AuthErrorResponse = { code: "VALIDATION_ERROR", message: parsed.error.issues[0].message };
     res.status(400).json(err);
@@ -148,6 +154,7 @@ app.post("/auth/verify-email", verifyResendRateLimit, (req, res) => {
 
   const accountId = tokenStore.consume(parsed.data.token, "verify");
   if (!accountId) {
+    authAuditLog(req, "verify_email", "failure", { code: "INVALID_TOKEN" });
     recordAuthEvent("verify_email", "failure", Date.now() - t0);
     const err: AuthErrorResponse = { code: "INVALID_TOKEN", message: "Verification token is invalid or expired." };
     res.status(400).json(err);
@@ -156,6 +163,7 @@ app.post("/auth/verify-email", verifyResendRateLimit, (req, res) => {
 
   const account = accounts.get(accountId);
   if (!account) {
+    authAuditLog(req, "verify_email", "failure", { code: "INVALID_TOKEN" });
     recordAuthEvent("verify_email", "failure", Date.now() - t0);
     const err: AuthErrorResponse = { code: "INVALID_TOKEN", message: "Verification token is invalid or expired." };
     res.status(400).json(err);
@@ -165,6 +173,7 @@ app.post("/auth/verify-email", verifyResendRateLimit, (req, res) => {
   account.verified = true;
   account.updatedAt = new Date();
   recordAuthEvent("verify_email", "success", Date.now() - t0);
+  authAuditLog(req, "verify_email", "success", { accountId: account.id });
   const body: VerifyEmailResponse = { message: "Email verified." };
   res.status(200).json(body);
 });
@@ -175,6 +184,7 @@ app.post("/auth/login", loginRateLimit, async (req, res) => {
   const t0 = Date.now();
   const parsed = loginSchema.safeParse(req.body);
   if (!parsed.success) {
+    authAuditLog(req, "login", "failure", { code: "VALIDATION_ERROR" });
     recordAuthEvent("login", "failure", Date.now() - t0);
     const err: AuthErrorResponse = { code: "VALIDATION_ERROR", message: parsed.error.issues[0].message };
     res.status(400).json(err);
@@ -187,6 +197,7 @@ app.post("/auth/login", loginRateLimit, async (req, res) => {
 
   // Check lockout before verifying password to avoid timing leaks
   if (account && lockoutService.isLocked(account.id)) {
+    authAuditLog(req, "login", "failure", { code: "ACCOUNT_LOCKED", email });
     suspiciousLoginLogger.record({ timestamp: new Date().toISOString(), email, ip, reason: "ACCOUNT_LOCKED" });
     recordAuthEvent("login", "failure", Date.now() - t0);
     const err: AuthErrorResponse = { code: "ACCOUNT_LOCKED", message: "Account temporarily locked. Please try again later." };
@@ -208,6 +219,7 @@ app.post("/auth/login", loginRateLimit, async (req, res) => {
   lockoutService.recordSuccess(account.id);
   const session = sessionStore.create(account.id);
   recordAuthEvent("login", "success", Date.now() - t0);
+  authAuditLog(req, "login", "success", { accountId: account.id, email });
   const body: LoginResponse = {
     accessToken: session.sessionId,
     refreshToken: session.refreshToken,
@@ -245,6 +257,7 @@ app.post("/auth/password-reset/request", resetRateLimit, (req, res) => {
   const t0 = Date.now();
   const parsed = resetRequestSchema.safeParse(req.body);
   if (!parsed.success) {
+    authAuditLog(req, "password_reset_request", "failure", { code: "VALIDATION_ERROR" });
     recordAuthEvent("password_reset", "failure", Date.now() - t0);
     const err: AuthErrorResponse = { code: "VALIDATION_ERROR", message: parsed.error.issues[0].message };
     res.status(400).json(err);
@@ -260,6 +273,7 @@ app.post("/auth/password-reset/request", resetRateLimit, (req, res) => {
   }
 
   recordAuthEvent("password_reset", "success", Date.now() - t0);
+  authAuditLog(req, "password_reset_request", "success", { email: parsed.data.email });
   const body: PasswordResetRequestResponse = {
     message: "If that email is registered you will receive a reset link shortly."
   };
@@ -271,6 +285,7 @@ app.post("/auth/password-reset/request", resetRateLimit, (req, res) => {
 app.post("/auth/password-reset/complete", resetRateLimit, async (req, res) => {
   const parsed = resetCompleteSchema.safeParse(req.body);
   if (!parsed.success) {
+    authAuditLog(req, "password_reset_complete", "failure", { code: "VALIDATION_ERROR" });
     const err: AuthErrorResponse = { code: "VALIDATION_ERROR", message: parsed.error.issues[0].message };
     res.status(400).json(err);
     return;
@@ -278,6 +293,7 @@ app.post("/auth/password-reset/complete", resetRateLimit, async (req, res) => {
 
   const accountId = tokenStore.consume(parsed.data.token, "reset");
   if (!accountId) {
+    authAuditLog(req, "password_reset_complete", "failure", { code: "INVALID_TOKEN" });
     const err: AuthErrorResponse = { code: "INVALID_TOKEN", message: "Reset token is invalid or expired." };
     res.status(400).json(err);
     return;
@@ -285,6 +301,7 @@ app.post("/auth/password-reset/complete", resetRateLimit, async (req, res) => {
 
   const account = accounts.get(accountId);
   if (!account) {
+    authAuditLog(req, "password_reset_complete", "failure", { code: "INVALID_TOKEN" });
     const err: AuthErrorResponse = { code: "INVALID_TOKEN", message: "Reset token is invalid or expired." };
     res.status(400).json(err);
     return;
@@ -297,7 +314,38 @@ app.post("/auth/password-reset/complete", resetRateLimit, async (req, res) => {
   sessionStore.revokeAll(accountId);
 
   const body: PasswordResetCompleteResponse = { message: "Password updated. Please log in again." };
+  authAuditLog(req, "password_reset_complete", "success", { accountId: account.id });
   res.status(200).json(body);
+});
+
+// Development-only shortcut for local auth fixture seeding.
+app.post("/auth/dev/seed-user", async (req, res) => {
+  if (env.APP_ENV !== "development" || env.ENABLE_DEV_AUTH_SHORTCUTS !== "true") {
+    const err: AuthErrorResponse = { code: "NOT_FOUND", message: "Route not found." };
+    res.status(404).json(err);
+    return;
+  }
+
+  const parsed = registerSchema.safeParse(req.body);
+  if (!parsed.success) {
+    const err: AuthErrorResponse = { code: "VALIDATION_ERROR", message: parsed.error.issues[0].message };
+    res.status(400).json(err);
+    return;
+  }
+
+  const { email, password } = parsed.data;
+  const now = new Date();
+  const account: Account = {
+    id: String(nextId++),
+    email,
+    passwordHash: await hashPassword(password),
+    verified: true,
+    createdAt: now,
+    updatedAt: now
+  };
+  accounts.set(account.id, account);
+  authAuditLog(req, "register", "success", { accountId: account.id, shortcut: true });
+  res.status(201).json({ id: account.id, email: account.email, verified: true });
 });
 
 // ── Logout (single device) ────────────────────────────────────────────────────
@@ -352,3 +400,4 @@ app.get("/auth/metrics", (_req, res) => {
 
 export { env };
 export { resetMetrics } from "./services/authMetrics.js";
+    authAuditLog(req, "login", "failure", { code: "INVALID_CREDENTIALS", email });

--- a/apps/api/src/services/authAuditLog.ts
+++ b/apps/api/src/services/authAuditLog.ts
@@ -1,0 +1,27 @@
+import type { Request } from "express";
+
+export type AuthAction =
+  | "register"
+  | "login"
+  | "logout"
+  | "verify_email"
+  | "password_reset_request"
+  | "password_reset_complete";
+
+export function authAuditLog(
+  req: Request,
+  action: AuthAction,
+  outcome: "success" | "failure",
+  metadata: Record<string, unknown> = {}
+): void {
+  const payload = {
+    event: "auth.audit",
+    action,
+    outcome,
+    requestId: req.header("x-request-id") ?? "none",
+    ip: req.ip ?? "unknown",
+    timestamp: new Date().toISOString(),
+    ...metadata
+  };
+  console.info(JSON.stringify(payload));
+}

--- a/apps/api/src/services/sessionStore.ts
+++ b/apps/api/src/services/sessionStore.ts
@@ -19,6 +19,8 @@ export interface SessionStore {
   getBySessionId(sessionId: string): Session | undefined;
   /** Look up a session by its refreshToken. Returns undefined if not found or already rotated. */
   getByRefreshToken(refreshToken: string): Session | undefined;
+  /** Returns true when token was previously valid but has been rotated/revoked. */
+  wasRefreshTokenSeen(refreshToken: string): boolean;
   /** Rotate the refresh token for a session; invalidates the old refreshToken. */
   rotate(sessionId: string): Session;
   /** Revoke a single session. */
@@ -39,6 +41,7 @@ export class MemorySessionStore implements SessionStore {
   private readonly sessions = new Map<string, Session>();
   /** refreshToken → sessionId index for O(1) lookup */
   private readonly byRefresh = new Map<string, string>();
+  private readonly seenRefreshTokens = new Set<string>();
 
   create(accountId: string): Session {
     const session: Session = {
@@ -49,6 +52,7 @@ export class MemorySessionStore implements SessionStore {
     };
     this.sessions.set(session.sessionId, session);
     this.byRefresh.set(session.refreshToken, session.sessionId);
+    this.seenRefreshTokens.add(session.refreshToken);
     return session;
   }
 
@@ -61,6 +65,10 @@ export class MemorySessionStore implements SessionStore {
     return sessionId ? this.sessions.get(sessionId) : undefined;
   }
 
+  wasRefreshTokenSeen(refreshToken: string): boolean {
+    return this.seenRefreshTokens.has(refreshToken);
+  }
+
   rotate(sessionId: string): Session {
     const existing = this.sessions.get(sessionId);
     if (!existing) throw new Error("Session not found");
@@ -71,6 +79,7 @@ export class MemorySessionStore implements SessionStore {
     const updated: Session = { ...existing, refreshToken: newToken() };
     this.sessions.set(sessionId, updated);
     this.byRefresh.set(updated.refreshToken, sessionId);
+    this.seenRefreshTokens.add(updated.refreshToken);
     return updated;
   }
 


### PR DESCRIPTION
## Summary
Minimal auth hardening pass for the assigned issue set, keeping implementation lightweight for MVP contributors.

## Included
- Added auth feature-flag rollout baseline documentation and password policy decision record (apps/api/AUTH_DECISIONS.md).
- Added a flag-gated auth capability endpoint (GET /auth/sessions) via ENABLE_AUTH_SESSION_LIST.
- Added refresh-token reuse detection signal path by tracking seen refresh tokens and logging suspicious replay attempts.
- Added test coverage for refresh-token replay behavior.
- Linked decision docs from root README for discoverability.

## Notes
- This intentionally avoids heavyweight infrastructure and keeps all behavior local/in-memory for starter ergonomics.

Closes #401
Closes #402
Closes #403
Closes #404
