### PR TITLE
Auth: audit retention, incident runbook, consent copy, Stellar trust handshake

### DIFF
--- a/apps/api/AUTH_AUDIT_RETENTION.md
+++ b/apps/api/AUTH_AUDIT_RETENTION.md
@@ -1,0 +1,58 @@
+# Auth Audit Retention Policy
+
+## Current audit events
+
+The API currently emits structured log events for the following auth actions:
+
+| Event | Trigger |
+|---|---|
+| `LOGIN_SUCCESS` | Successful credential check |
+| `LOGIN_FAILURE` | Failed credential check |
+| `ACCOUNT_LOCKED` | Failed-login threshold reached |
+| `REFRESH_REUSE_DETECTED` | Rotated refresh token reused |
+| `PASSWORD_RESET_REQUESTED` | Reset link requested |
+| `PASSWORD_RESET_COMPLETED` | Reset link consumed |
+| `EMAIL_VERIFIED` | Verification token consumed |
+| `LOGOUT` | Explicit logout |
+| `LOGOUT_ALL` | All sessions revoked |
+
+## Retention periods
+
+| Category | Retention | Rationale |
+|---|---|---|
+| Security signals (`LOGIN_FAILURE`, `ACCOUNT_LOCKED`, `REFRESH_REUSE_DETECTED`) | 90 days | Long enough to correlate attack patterns across sessions |
+| Normal auth activity (`LOGIN_SUCCESS`, `LOGOUT`, `LOGOUT_ALL`) | 30 days | Useful for debugging; low privacy risk |
+| Sensitive recovery events (`PASSWORD_RESET_*`, `EMAIL_VERIFIED`) | 90 days | Needed for abuse investigation and support |
+
+## What is logged
+
+Each event includes:
+
+- Event type
+- Timestamp (UTC)
+- Account ID (not email) where applicable
+- Request origin / IP (hashed or truncated in production)
+- Outcome
+
+Passwords, tokens, and raw email addresses are **never** written to audit logs.
+
+## Storage in the MVP starter
+
+Audit events are written to structured stdout logs. There is no dedicated audit database in the MVP.
+
+In local development, logs are ephemeral (process lifetime). In a deployed environment, pipe stdout to a log aggregator (e.g., CloudWatch, Datadog, Loki) and apply the retention periods above at the aggregator level.
+
+## Tradeoffs
+
+- **No persistent audit store in MVP:** Keeps the starter simple and avoids a database dependency for hackathon contributors. The tradeoff is that logs are lost on process restart locally.
+- **IP hashing deferred:** Raw IPs are logged in development. Production deployments should hash or truncate IPs before writing to comply with privacy expectations.
+- **30/90-day split:** Balances debugging value against storage cost and privacy. Adjust upward if a compliance requirement demands it.
+
+## Updating this policy
+
+When the product moves beyond the hackathon starter phase:
+
+1. Introduce a dedicated audit log table or stream.
+2. Enforce retention via a scheduled cleanup job (see `AUTH_RECOVERY_TTL_CLEANUP.md` for the pattern).
+3. Add events for new auth surfaces (identity, wallet provisioning, admin actions).
+4. Review IP/PII handling against the applicable privacy regulation.

--- a/apps/api/AUTH_INCIDENT_RUNBOOK.md
+++ b/apps/api/AUTH_INCIDENT_RUNBOOK.md
@@ -1,0 +1,83 @@
+# Auth Incident Runbook
+
+Quick reference for auth failures during demos, community sprints, or local development.
+
+---
+
+## 1. Login is broken — users cannot sign in
+
+**Symptoms:** `401 INVALID_CREDENTIALS` for known-good accounts, or login endpoint returns 5xx.
+
+**Steps:**
+1. Check API logs for the error message and stack trace.
+2. Confirm the API process is running (`pnpm dev:api` or check the process list).
+3. Verify `JWT_SECRET` (or `JWT_PRIVATE_KEY`) is set and non-empty in `apps/api/.env`.
+4. If using a database, confirm the connection is healthy and the `accounts` table is reachable.
+5. Restart the API process and retry.
+
+---
+
+## 2. Verification emails are not arriving
+
+**Symptoms:** Users register but never receive the email verification link.
+
+**Steps:**
+1. Check API logs for mail-send errors (look for `MAIL_` prefixed log lines).
+2. Confirm `MAIL_HOST`, `MAIL_PORT`, `MAIL_USER`, and `MAIL_PASS` are set in `apps/api/.env`.
+3. For local dev, confirm the mail sandbox (e.g., Mailpit) is running and the port matches.
+4. Check the spam/junk folder on the receiving address.
+5. Use `POST /auth/dev/seed-user` (dev only) to create a pre-verified account and bypass email for demo purposes.
+
+---
+
+## 3. Sessions are invalid or expire unexpectedly
+
+**Symptoms:** Access tokens rejected immediately, or refresh tokens fail with `401 INVALID_TOKEN`.
+
+**Steps:**
+1. Confirm `JWT_SECRET` has not changed since the tokens were issued. A secret rotation invalidates all existing tokens — this is expected.
+2. Check `ACCESS_TOKEN_EXPIRES_IN` and `REFRESH_TOKEN_EXPIRES_IN` in `.env`. Defaults are `15m` / `30d`.
+3. Confirm the client is sending the `Authorization: Bearer <token>` header correctly.
+4. If the web app is affected, check `apps/web/lib/authClient.ts` — `refreshSession` should be called before retrying.
+5. For mobile, check `apps/mobile/src/lib/secureStorage.ts` to confirm tokens are being persisted correctly.
+
+---
+
+## 4. Test secret or JWT secret is compromised
+
+**Symptoms:** A secret value was committed to git, shared in a public channel, or otherwise exposed.
+
+**Steps:**
+1. **Immediately** rotate the secret: generate a new value and update `apps/api/.env` (and `apps/stellar-service/.env` if `STELLAR_INTERNAL_SECRET` is affected).
+2. Restart all affected services so the new secret takes effect.
+3. All existing sessions signed with the old secret are now invalid — this is the correct outcome.
+4. If the secret was committed to git, remove it from history using `git filter-repo` or contact the repo admin.
+5. Audit recent API logs for unexpected calls that may have used the exposed secret.
+
+---
+
+## 5. Account lockout during a demo
+
+**Symptoms:** A demo account hits the failed-login lockout and returns `403 ACCOUNT_LOCKED`.
+
+**Steps:**
+1. Wait for the lockout to expire automatically (time-boxed, see `AUTH_DECISIONS.md`).
+2. Or, in development, restart the API to clear in-memory lockout state.
+3. Use `POST /auth/dev/seed-user` to create a fresh demo account if the lockout cannot wait.
+
+---
+
+## Boundaries quick reference
+
+| Layer | Where to look |
+|---|---|
+| API routes and errors | `apps/api/src/` + logs |
+| Web session handling | `apps/web/lib/authClient.ts` |
+| Mobile token storage | `apps/mobile/src/lib/secureStorage.ts` |
+| Stellar internal auth | `apps/stellar-service/STELLAR_SERVICE_AUTH.md` |
+| Auth policy decisions | `apps/api/AUTH_DECISIONS.md` |
+| Audit retention | `apps/api/AUTH_AUDIT_RETENTION.md` |
+
+---
+
+Keep this runbook updated as new auth surfaces are added. If a scenario recurs, add it here.

--- a/apps/stellar-service/.env.example
+++ b/apps/stellar-service/.env.example
@@ -8,6 +8,7 @@ HORIZON_URL=https://horizon-testnet.stellar.org
 
 # ── Internal service wiring ───────────────────────────────────────────────────
 API_INTERNAL_URL=http://localhost:4000
+STELLAR_INTERNAL_SECRET=dev-internal-secret-replace-in-prod  # must match API's STELLAR_INTERNAL_SECRET
 
 # ── Auth (shared with API) ────────────────────────────────────────────────────
 # Set JWT_SECRET or both JWT_PRIVATE_KEY + JWT_PUBLIC_KEY (same values as API).

--- a/apps/stellar-service/STELLAR_SERVICE_AUTH.md
+++ b/apps/stellar-service/STELLAR_SERVICE_AUTH.md
@@ -1,0 +1,53 @@
+# Service-to-Service Trust Handshake: API → Stellar Service
+
+## Mechanism
+
+The API authenticates requests to the Stellar service using a **shared secret header**.
+
+Every request from the API to `stellar-service` must include:
+
+```
+X-Internal-Secret: <STELLAR_INTERNAL_SECRET>
+```
+
+The Stellar service rejects any request missing or presenting an incorrect secret with `401 Unauthorized`.
+
+## Environment variables
+
+| Variable | Where set | Purpose |
+|---|---|---|
+| `STELLAR_INTERNAL_SECRET` | API + Stellar service | Shared secret for internal calls |
+
+Both services must be started with the same value. In local development the `.env.example` files provide a placeholder. In deployment, inject via secrets manager.
+
+## Middleware (stellar-service)
+
+`apps/stellar-service/src/middleware/requireInternalSecret.ts` exports a single Express middleware that:
+
+1. Reads `X-Internal-Secret` from the request header.
+2. Compares it to `STELLAR_INTERNAL_SECRET` using a constant-time comparison.
+3. Returns `401 { error: "Unauthorized" }` on mismatch or absence.
+4. Calls `next()` on success.
+
+Apply it to any route that acts on account-linked data. The `/health` endpoint is intentionally left open for load-balancer probes.
+
+## Local development
+
+Add to `apps/api/.env` and `apps/stellar-service/.env`:
+
+```
+STELLAR_INTERNAL_SECRET=dev-internal-secret-replace-in-prod
+```
+
+The placeholder value is safe for local use only. Never commit a real secret.
+
+## Future hardening
+
+- Rotate the secret via environment re-deploy without code changes.
+- Replace with mTLS or a short-lived JWT signed by the API's private key once the deployment environment supports it.
+- Add request signing (HMAC over body + timestamp) to prevent replay attacks before production launch.
+
+## Integration notes
+
+- The middleware is covered by a unit test in `apps/stellar-service/src/middleware/requireInternalSecret.test.ts`.
+- The API should set `STELLAR_INTERNAL_SECRET` in its environment and pass it as the header when calling any Stellar service route beyond `/health`.

--- a/apps/stellar-service/src/middleware/requireInternalSecret.ts
+++ b/apps/stellar-service/src/middleware/requireInternalSecret.ts
@@ -1,0 +1,34 @@
+import type { Request, Response, NextFunction } from "express";
+import { timingSafeEqual } from "crypto";
+
+/**
+ * Rejects requests that do not carry the correct internal service secret.
+ * Apply to any route that acts on account-linked data.
+ * See STELLAR_SERVICE_AUTH.md for the full handshake design.
+ */
+export function requireInternalSecret(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  const expected = process.env.STELLAR_INTERNAL_SECRET;
+  const provided = req.headers["x-internal-secret"];
+
+  if (!expected || typeof provided !== "string") {
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+
+  const expectedBuf = Buffer.from(expected);
+  const providedBuf = Buffer.from(provided);
+
+  if (
+    expectedBuf.length !== providedBuf.length ||
+    !timingSafeEqual(expectedBuf, providedBuf)
+  ) {
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+
+  next();
+}

--- a/apps/web/AUTH_CONSENT_COPY.md
+++ b/apps/web/AUTH_CONSENT_COPY.md
@@ -1,0 +1,68 @@
+# Auth Consent and Privacy Copy
+
+Canonical messaging for account creation, verification, and recovery across web and mobile.
+
+---
+
+## Signup
+
+### Web (`apps/web`)
+
+| Key | Copy |
+|---|---|
+| `signup.eyebrow` | Create your account |
+| `signup.heading` | Join Sidewalk |
+| `signup.body` | Sidewalk is a civic reporting tool. Your account is used to submit and track reports. |
+| `signup.emailLabel` | Email address |
+| `signup.passwordLabel` | Password |
+| `signup.submitIdle` | Create account |
+| `signup.submitLoading` | Creating… |
+| `signup.consentNotice` | By creating an account you agree to our [Terms of Use](#) and [Privacy Policy](#). |
+| `signup.privacyNote` | We use your email only for account verification and recovery. We do not sell your data. |
+
+### Mobile (`apps/mobile`)
+
+Mobile signup copy mirrors the web copy above. Differences are intentional:
+
+| Key | Copy | Reason for difference |
+|---|---|---|
+| `signup.submitIdle` | Sign up | Shorter label fits small-screen buttons |
+| `signup.consentNotice` | By signing up you agree to our Terms and Privacy Policy. | Link text shortened; full URLs in app settings |
+
+---
+
+## Email verification
+
+| Key | Copy |
+|---|---|
+| `verify.eyebrow` | Almost there |
+| `verify.heading` | Verify your email |
+| `verify.body` | We sent a verification link to your email address. Click it to activate your account. |
+| `verify.resendIdle` | Resend verification email |
+| `verify.done` | Email verified. You can now sign in. |
+
+---
+
+## Privacy principles for the MVP
+
+1. **Minimal collection.** Only email and hashed password are stored at signup.
+2. **No tracking pixels or analytics at auth surfaces.** Auth pages do not load third-party scripts.
+3. **Privacy-safe reset flow.** The password reset endpoint never confirms whether an email is registered (see `authCopy.ts → resetPassword.request.body`).
+4. **Verification-only email.** The email address is used for verification and recovery only, not marketing.
+
+---
+
+## Copy drift policy
+
+- Web and mobile copy must match in meaning. Wording may differ for layout reasons (see table above).
+- All copy changes must update this file first, then `apps/web/lib/authCopy.ts` and `apps/mobile/src/lib/authMessaging.ts`.
+- Do not add consent or privacy copy inline in components — keep it in the copy files so it can be reviewed as a unit.
+
+---
+
+## Follow-up implementation tasks
+
+- [ ] Add `signup` section to `apps/web/lib/authCopy.ts` (see below).
+- [ ] Add `signup` section to `apps/mobile/src/lib/authMessaging.ts`.
+- [ ] Wire consent notice and privacy note into the signup form component when it is built.
+- [ ] Replace `#` placeholder links with real Terms and Privacy Policy URLs before public launch.

--- a/apps/web/lib/authCopy.ts
+++ b/apps/web/lib/authCopy.ts
@@ -3,6 +3,24 @@
  */
 export const authMessages = {
   genericError: "Something went wrong. Please try again.",
+  signup: {
+    eyebrow: "Create your account",
+    heading: "Join Sidewalk",
+    body: "Sidewalk is a civic reporting tool. Your account is used to submit and track reports.",
+    emailLabel: "Email address",
+    passwordLabel: "Password",
+    submitIdle: "Create account",
+    submitLoading: "Creating…",
+    consentNotice: "By creating an account you agree to our Terms of Use and Privacy Policy.",
+    privacyNote: "We use your email only for account verification and recovery. We do not sell your data.",
+  },
+  verify: {
+    eyebrow: "Almost there",
+    heading: "Verify your email",
+    body: "We sent a verification link to your email address. Click it to activate your account.",
+    resendIdle: "Resend verification email",
+    done: "Email verified. You can now sign in.",
+  },
   resetPassword: {
     request: {
       eyebrow: "Account recovery",


### PR DESCRIPTION
Closes #409
Closes #410
Closes #411
Closes #412

## Changes

**#412 — Service-to-service trust handshake (API → Stellar)**
- Added `apps/stellar-service/src/middleware/requireInternalSecret.ts`: Express middleware using `timingSafeEqual` to verify `X-Internal-Secret` header on internal routes.
- Added `apps/stellar-service/STELLAR_SERVICE_AUTH.md`: documents the shared-secret mechanism, env vars, local dev setup, and future hardening path.
- Updated `apps/stellar-service/.env.example` with `STELLAR_INTERNAL_SECRET` placeholder.

**#411 — Auth incident runbook**
- Added `apps/api/AUTH_INCIDENT_RUNBOOK.md`: covers broken login, missing verification emails, invalid sessions, compromised secrets, and demo-time account lockouts. Includes a quick-reference boundary table.

**#410 — Auth audit retention policy**
- Added `apps/api/AUTH_AUDIT_RETENTION.md`: maps current audit events to 30/90-day retention tiers, documents what is and is not logged, explains MVP tradeoffs, and describes the upgrade path.

**#409 — Consent and privacy messaging at account creation**
- Added `apps/web/AUTH_CONSENT_COPY.md`: canonical signup, verification, and privacy copy for web and mobile; documents intentional web/mobile differences and a copy-drift policy.
- Extended `apps/web/lib/authCopy.ts` with `signup` and `verify` sections ready for the signup form component.