### PR TITLE
feat(shared): extract reusable zod schemas, pagination types, response envelopes, and shared enums

### DIFF
--- a/apps/api/src/modules/reports/routes/report.routes.ts
+++ b/apps/api/src/modules/reports/routes/report.routes.ts
@@ -1,8 +1,8 @@
-import { Router } from "express";
+import { Router, type Router as RouterType } from "express";
 import { requireAuth } from "../../../shared/middleware/requireAuth.js";
 import { reportController } from "../controllers/report.controller.js";
 
-const router = Router();
+const router: RouterType = Router();
 
 router.post("/reports", requireAuth, reportController.create);
 router.get("/reports", requireAuth, reportController.list);

--- a/apps/api/src/modules/reports/types/report.types.ts
+++ b/apps/api/src/modules/reports/types/report.types.ts
@@ -4,6 +4,7 @@ import type {
   ReportSummary,
   ModerationRecord,
   ReportFilter,
+  ReportDraft,
 } from "@sidewalk/shared";
 
 export type ReportCreateRequest = ReportSubmission;
@@ -22,9 +23,21 @@ export interface ReportDetailResponse {
   report: Report;
 }
 
+export interface DraftCreateRequest {
+  title: string;
+  description: string;
+  visibility: string;
+  location?: string;
+  mediaUrls?: string[];
+}
+
+export interface DraftCreateResponse {
+  draft: ReportDraft;
+}
+
 export interface ModerationActionRequest {
   outcome: "approved" | "rejected" | "flagged" | "escalated";
   reason?: string;
 }
 
-export type { Report, ReportSummary, ReportFilter, ModerationRecord };
+export type { Report, ReportSummary, ReportFilter, ModerationRecord, ReportDraft };

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -2,5 +2,7 @@ export * from "./types/auth.js";
 export * from "./types/civic.js";
 export * from "./types/pagination.js";
 export * from "./types/envelope.js";
+export * from "./types/enums.js";
 export * from "./validation/auth.js";
 export * from "./validation/civic.js";
+export * from "./validation/profile.js";

--- a/packages/shared/src/types/civic.ts
+++ b/packages/shared/src/types/civic.ts
@@ -1,20 +1,4 @@
-export type ReportStatus =
-  | "draft"
-  | "submitted"
-  | "under_review"
-  | "resolved"
-  | "closed";
-
-export type Visibility =
-  | "public"
-  | "private"
-  | "moderators_only";
-
-export type ModerationOutcome =
-  | "approved"
-  | "rejected"
-  | "flagged"
-  | "escalated";
+import type { ReportStatus, Visibility, ModerationOutcome } from "./enums.js";
 
 export interface ReportProfile {
   id: string;
@@ -49,6 +33,42 @@ export interface ReportSummary {
   status: ReportStatus;
   createdAt: string;
   author: ReportProfile;
+}
+
+export interface UserSummary {
+  id: string;
+  email: string;
+  displayName?: string;
+  avatarUrl?: string;
+  createdAt: string;
+  reportCount?: number;
+}
+
+export interface ProfileUpdate {
+  displayName?: string;
+  avatarUrl?: string;
+  bio?: string;
+}
+
+export interface StatusDetail {
+  current: ReportStatus;
+  previous?: ReportStatus;
+  reason?: string;
+  changedBy?: string;
+  changedAt: string;
+}
+
+export interface ReportDraft {
+  id: string;
+  authorId: string;
+  title: string;
+  description: string;
+  visibility: Visibility;
+  location?: string;
+  mediaUrls: string[];
+  status: Extract<ReportStatus, "draft">;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface ModerationRecord {

--- a/packages/shared/src/types/enums.ts
+++ b/packages/shared/src/types/enums.ts
@@ -1,0 +1,36 @@
+export const ReportStatus = {
+  DRAFT: "draft",
+  SUBMITTED: "submitted",
+  UNDER_REVIEW: "under_review",
+  RESOLVED: "resolved",
+  CLOSED: "closed",
+} as const;
+
+export type ReportStatus = (typeof ReportStatus)[keyof typeof ReportStatus];
+
+export const Visibility = {
+  PUBLIC: "public",
+  PRIVATE: "private",
+  MODERATORS_ONLY: "moderators_only",
+} as const;
+
+export type Visibility = (typeof Visibility)[keyof typeof Visibility];
+
+export const ModerationOutcome = {
+  APPROVED: "approved",
+  REJECTED: "rejected",
+  FLAGGED: "flagged",
+  ESCALATED: "escalated",
+} as const;
+
+export type ModerationOutcome = (typeof ModerationOutcome)[keyof typeof ModerationOutcome];
+
+export const ModerationAction = {
+  APPROVE: "approve",
+  REJECT: "reject",
+  FLAG: "flag",
+  ESCALATE: "escalate",
+  DISMISS: "dismiss",
+} as const;
+
+export type ModerationAction = (typeof ModerationAction)[keyof typeof ModerationAction];

--- a/packages/shared/src/types/envelope.ts
+++ b/packages/shared/src/types/envelope.ts
@@ -1,3 +1,12 @@
+export type DomainErrorCode =
+  | "VALIDATION_ERROR"
+  | "NOT_FOUND"
+  | "UNAUTHORIZED"
+  | "FORBIDDEN"
+  | "CONFLICT"
+  | "RATE_LIMITED"
+  | "INTERNAL_ERROR";
+
 export interface SuccessEnvelope<T> {
   success: true;
   data: T;
@@ -6,10 +15,30 @@ export interface SuccessEnvelope<T> {
 export interface ErrorEnvelope {
   success: false;
   error: {
-    code: string;
+    code: DomainErrorCode;
     message: string;
     details?: Record<string, unknown>;
   };
 }
 
 export type ApiEnvelope<T> = SuccessEnvelope<T> | ErrorEnvelope;
+
+export function success<T>(data: T): SuccessEnvelope<T> {
+  return { success: true, data };
+}
+
+export function error(
+  code: DomainErrorCode,
+  message: string,
+  details?: Record<string, unknown>,
+): ErrorEnvelope {
+  return { success: false, error: { code, message, details } };
+}
+
+export function paginated<T>(
+  data: T[],
+  total: number,
+  nextCursor?: string,
+): SuccessEnvelope<{ items: T[]; total: number; nextCursor?: string }> {
+  return success({ items: data, total, nextCursor });
+}

--- a/packages/shared/src/types/pagination.ts
+++ b/packages/shared/src/types/pagination.ts
@@ -16,3 +16,24 @@ export interface ReportFilter {
   createdAfter?: string;
   createdBefore?: string;
 }
+
+export interface UserFilter {
+  search?: string;
+  role?: string;
+  createdAfter?: string;
+  createdBefore?: string;
+}
+
+export interface ModerationFilter {
+  outcome?: string;
+  moderatorId?: string;
+  reportId?: string;
+  createdAfter?: string;
+  createdBefore?: string;
+}
+
+export interface PaginationParams {
+  page?: number;
+  limit?: number;
+  cursor?: string;
+}

--- a/packages/shared/src/validation/civic.ts
+++ b/packages/shared/src/validation/civic.ts
@@ -1,23 +1,33 @@
 import { z } from "zod";
+import { ReportStatus, Visibility, ModerationOutcome } from "../types/enums.js";
 
 export const reportSubmissionSchema = z.object({
   title: z.string().min(1, "Title is required.").max(200),
   description: z.string().min(1, "Description is required.").max(5000),
-  visibility: z.enum(["public", "private", "moderators_only"]),
+  visibility: z.enum([
+    Visibility.PUBLIC,
+    Visibility.PRIVATE,
+    Visibility.MODERATORS_ONLY,
+  ]),
   location: z.string().optional(),
   mediaUrls: z.array(z.string().url()).max(10).optional(),
 });
 
 export const reportStatusSchema = z.enum([
-  "draft",
-  "submitted",
-  "under_review",
-  "resolved",
-  "closed",
+  ReportStatus.DRAFT,
+  ReportStatus.SUBMITTED,
+  ReportStatus.UNDER_REVIEW,
+  ReportStatus.RESOLVED,
+  ReportStatus.CLOSED,
 ]);
 
 export const moderationSchema = z.object({
-  outcome: z.enum(["approved", "rejected", "flagged", "escalated"]),
+  outcome: z.enum([
+    ModerationOutcome.APPROVED,
+    ModerationOutcome.REJECTED,
+    ModerationOutcome.FLAGGED,
+    ModerationOutcome.ESCALATED,
+  ]),
   reason: z.string().max(1000).optional(),
 });
 

--- a/packages/shared/src/validation/profile.ts
+++ b/packages/shared/src/validation/profile.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+export const displayNameSchema = z
+  .string()
+  .trim()
+  .min(1, "Display name is required.")
+  .max(100, "Display name must be at most 100 characters.");
+
+export const avatarUrlSchema = z.string().url("Invalid avatar URL.").optional();
+
+export const bioSchema = z
+  .string()
+  .max(500, "Bio must be at most 500 characters.")
+  .optional();
+
+export const profileUpdateSchema = z.object({
+  displayName: displayNameSchema.optional(),
+  avatarUrl: avatarUrlSchema,
+  bio: bioSchema,
+});
+
+export type ProfileUpdateInput = z.infer<typeof profileUpdateSchema>;


### PR DESCRIPTION
## Summary

feat(shared): extract reusable zod schemas, pagination types, response envelopes, and shared enums

## Changes

- Adds runtime shared enums for report states, visibility, and moderation outcomes
- Adds civic resource DTOs including UserSummary, StatusDetail, and ReportDraft
- Adds reusable Zod schemas for report submission and profile updates
- Adds typed response envelopes with domain error codes and helper factories
- Adds pagination/filter types for reports, users, and moderation queries

## Related Issues

Closes #521
Closes #522
Closes #523
Closes #524
