### PR TITLE
docs: add package boundary rules and cross-package review checklist

### DIFF
--- a/docs/cross-package-review-checklist.md
+++ b/docs/cross-package-review-checklist.md
@@ -1,0 +1,69 @@
+# Cross-Package Review Checklist
+
+Use this checklist when reviewing a pull request that touches more than one package or application in the monorepo (e.g. a change to `packages/shared` alongside a change in `apps/api`).
+
+---
+
+## When to apply this checklist
+
+Apply it whenever a PR modifies files in:
+
+- `packages/shared` **and** at least one app, or
+- `packages/stellar` **and** at least one app, or
+- two or more apps at once, or
+- any `packages/*` entry point (`index.ts`, exported types).
+
+Single-app changes that stay entirely within one `apps/*` directory do not require this checklist.
+
+---
+
+## Checklist
+
+### Dependency direction
+
+- [ ] No `apps/*` package imports from another `apps/*` package.
+- [ ] No `packages/*` package imports from `apps/*`.
+- [ ] `packages/stellar` does not import from anything other than `packages/shared`.
+- [ ] No new circular dependencies are introduced (`pnpm check` or `tsc --noEmit` across the workspace stays clean).
+
+### Shared package changes (`packages/shared`, `packages/stellar`)
+
+- [ ] Every new export in `packages/shared` is consumed by at least two packages/apps (or a follow-up issue is filed to track the second consumer).
+- [ ] No business logic or application-specific behaviour has been added to `packages/shared`.
+- [ ] Stellar SDK calls and receipt logic land in `packages/stellar`, not in `apps/*` directly.
+- [ ] Public API changes (renamed or removed exports) are reflected in every consumer in the same PR.
+
+### Type safety
+
+- [ ] `pnpm typecheck` passes across the full workspace with no new errors.
+- [ ] No types are duplicated across packages — if the same shape appears in two places, it belongs in `packages/shared`.
+
+### Tests
+
+- [ ] Behaviour added or changed in a shared package is covered by tests in that package (or, if only validated by build/lint, that is explicitly noted in the PR description).
+- [ ] Consumer apps that are affected by the shared change have their own tests updated to reflect the new behaviour.
+- [ ] `pnpm test` passes across all affected packages.
+
+### CI
+
+- [ ] All GitHub Actions workflows triggered by the PR are green (lint, typecheck, test, build).
+- [ ] No workflow is skipped or has its failure silenced without a documented reason.
+
+### PR description
+
+- [ ] The description explains why the change needs to touch multiple packages rather than staying in one.
+- [ ] Any intentional deviation from the [package boundary rules](package-boundaries.md) is called out explicitly.
+- [ ] Breaking changes to shared types or interfaces are highlighted so dependent teams can prepare.
+
+---
+
+## Quick reference: allowed dependency graph
+
+```
+apps/api     → packages/shared, packages/stellar
+apps/web     → packages/shared
+apps/mobile  → packages/shared
+packages/stellar → packages/shared
+```
+
+Any import that flows against this graph is a boundary violation and must be resolved before merge.

--- a/docs/package-boundaries.md
+++ b/docs/package-boundaries.md
@@ -1,0 +1,116 @@
+# Package Boundary Rules
+
+This document defines what each package and application in the Sidewalk monorepo owns, what it may depend on, and what it must not do.
+
+---
+
+## Monorepo Shape
+
+```text
+sidewalk/
+├── apps/
+│   ├── api/       # Express modular monolith
+│   ├── web/       # Next.js web UI
+│   └── mobile/    # Expo / React Native app
+└── packages/
+    ├── shared/    # Shared types and validation schemas
+    └── stellar/   # Stellar integration scaffold
+```
+
+---
+
+## Package Rules
+
+### `packages/shared`
+
+**Owns:** TypeScript types, Zod validation schemas, and constants that are consumed by more than one app.
+
+**May depend on:** nothing in this monorepo.
+
+**Must not:**
+- Contain business logic or application-level behaviour.
+- Import from `apps/*` or `packages/stellar`.
+- Grow into a general-purpose utilities dumping ground — every export must have at least two consumers.
+
+---
+
+### `packages/stellar`
+
+**Owns:** Stellar SDK integration, transaction helpers, and verification receipt logic.
+
+**May depend on:** `packages/shared`.
+
+**Must not:**
+- Import from any `apps/*` package.
+- Contain UI components or HTTP route handlers.
+- Hold application configuration (keys, network URLs) — those belong in the consuming app's environment.
+
+---
+
+### `apps/api`
+
+**Owns:** HTTP route handlers, business logic, database access (Prisma), and authentication flows.
+
+Internal structure follows the modular monolith pattern: each domain lives under `src/modules/<domain>/`. Cross-cutting infrastructure (middleware, logger, database client, error types) lives in `src/shared/`.
+
+**May depend on:** `packages/shared`, `packages/stellar`.
+
+**Must not:**
+- Import from `apps/web` or `apps/mobile`.
+- Put business logic in `src/shared/` — that directory is for infrastructure only.
+- Introduce a global `controllers/` or `services/` layer outside of a module directory.
+
+---
+
+### `apps/web`
+
+**Owns:** Next.js pages, React components, and client-side state for the web UI.
+
+**May depend on:** `packages/shared`.
+
+**Must not:**
+- Import from `apps/api` or `apps/mobile`.
+- Call the Stellar SDK directly — go through `packages/stellar` if Stellar functionality is needed in the browser.
+- Duplicate types that already exist in `packages/shared`.
+
+---
+
+### `apps/mobile`
+
+**Owns:** Expo screens, React Native components, navigation, and mobile-specific hooks and services.
+
+**May depend on:** `packages/shared`.
+
+**Must not:**
+- Import from `apps/api` or `apps/web`.
+- Call the Stellar SDK directly — go through `packages/stellar` if needed.
+- Duplicate types that already exist in `packages/shared`.
+
+---
+
+## Dependency Direction
+
+The allowed dependency graph flows in one direction only:
+
+```
+apps/* → packages/shared
+apps/* → packages/stellar
+packages/stellar → packages/shared
+```
+
+No package or app may create a circular dependency or import upward from `packages/` into `apps/`.
+
+---
+
+## Adding Something New
+
+| What you are adding | Where it goes |
+|---|---|
+| Type used by two or more apps | `packages/shared` |
+| Stellar SDK call or receipt logic | `packages/stellar` |
+| HTTP endpoint or business logic | `apps/api/src/modules/<domain>/` |
+| Web UI component or page | `apps/web` |
+| Mobile screen or component | `apps/mobile` |
+| Cross-cutting API infra (middleware, logger) | `apps/api/src/shared/` |
+
+When in doubt, keep it in the app that needs it first. Move it to a shared package only when a second consumer appears.


### PR DESCRIPTION
## Summary

Adds two documentation files to resolve the developer workflow issues in sprint 1.

### docs/package-boundaries.md
Defines what each package and app in the monorepo owns, what it may depend on, and what it must not do. Covers `packages/shared`, `packages/stellar`, `apps/api`, `apps/web`, and `apps/mobile`, with a dependency direction diagram and a quick reference table for where new code belongs.

### docs/cross-package-review-checklist.md
A reviewer checklist for PRs that touch more than one package. Covers dependency direction, shared package rules, type safety, test coverage, CI expectations, and PR description requirements.

Closes #568
Closes #569