### PR TITLE
docs: contributor bootstrap, module guide, reset workflow, indexing strategy

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -25,12 +25,170 @@ routes, types, and tests:
 modules/
   auth/        # registration, login, token issuance
   users/       # user lookups used to support authentication
+  reports/     # civic report submission, listing, and moderation
 shared/        # cross-cutting config, database, middleware, errors, logger
 ```
 
 New backend functionality should be added as a new module under
 `src/modules/`, following the same internal structure. Avoid putting business
 logic in `shared/` — it is for cross-cutting infrastructure only.
+
+---
+
+## Repo Bootstrap Path
+
+If you are starting from the auth starter (the current state of this repo),
+follow these steps to get a working local environment from scratch.
+
+### 1. Prerequisites
+
+- Node.js 20+
+- pnpm 10+
+
+### 2. Clone and install
+
+```bash
+git clone https://github.com/MixMatch-Inc/Sidewalk.git
+cd Sidewalk
+pnpm install
+```
+
+### 3. Configure environment variables
+
+Each app ships an `.env.example`. Copy the relevant one(s) before running:
+
+```bash
+cp apps/api/.env.example apps/api/.env
+cp apps/web/.env.example apps/web/.env
+cp apps/mobile/.env.example apps/mobile/.env
+```
+
+See [docs/environment.md](environment.md) for a description of every variable.
+
+### 4. Set up the API database
+
+The API uses Prisma with a local SQLite file by default. Generate the Prisma
+client and push the schema on first run:
+
+```bash
+pnpm --filter @sidewalk/api exec prisma generate
+pnpm --filter @sidewalk/api exec prisma db push
+```
+
+### 5. Start the apps
+
+```bash
+pnpm dev:api      # http://localhost:4000
+pnpm dev:web      # http://localhost:3000
+pnpm dev:mobile   # Expo dev server
+```
+
+Once both are running, visit `http://localhost:3000` to create an account and
+log in.
+
+### 6. Verify the setup
+
+```bash
+pnpm check   # runs lint + typecheck + test + build across all packages
+```
+
+All checks should pass on a fresh clone before you make any changes.
+
+---
+
+## Adding a New Module
+
+New product domains (e.g. `reports`, `identity`, `notifications`) live as
+sibling modules next to `auth` under `apps/api/src/modules/`. Follow the
+pattern established by the existing modules so that new code integrates
+without requiring changes to the core `shared/` infrastructure.
+
+### 1. Create the module directory
+
+```bash
+mkdir -p apps/api/src/modules/<name>/{controllers,services,routes,validators,types,tests}
+```
+
+Replace `<name>` with the domain name in kebab-case (e.g. `reports`).
+
+### 2. Lay down the standard files
+
+Each module must contain at minimum:
+
+| File | Purpose |
+| ---- | ------- |
+| `routes/<name>.routes.ts` | Express router — mounts controllers onto URL paths |
+| `controllers/<name>.controller.ts` | Request/response handling; no business logic |
+| `services/<name>.service.ts` | Business logic; calls the database or repositories |
+| `validators/<name>.validator.ts` | Zod schemas for request body validation |
+| `types/<name>.types.ts` | Local TypeScript types (re-export from shared if needed) |
+| `tests/<name>.test.ts` | Vitest integration tests via `supertest` |
+
+Use the `auth` module as the canonical reference:
+
+```text
+apps/api/src/modules/auth/
+  controllers/auth.controller.ts
+  services/auth.service.ts
+  routes/auth.routes.ts
+  validators/auth.validator.ts
+  types/auth.types.ts
+  tests/auth.test.ts
+```
+
+### 3. Register the router in `src/app.ts`
+
+Import and mount the new router alongside the existing ones in
+`apps/api/src/app.ts`:
+
+```ts
+import { newModuleRouter } from './modules/<name>/routes/<name>.routes.js';
+
+// inside the app setup function:
+app.use('/api/<name>', newModuleRouter);
+```
+
+### 4. Add shared types (if needed)
+
+If the module introduces types consumed by the web or mobile apps, add them
+to `packages/shared/src/types/` and re-export from
+`packages/shared/src/index.ts`.
+
+Keep `packages/shared` minimal — only add types that are genuinely used by
+more than one app.
+
+### 5. Update the Prisma schema (if needed)
+
+Add models to `apps/api/prisma/schema.prisma`, then regenerate and push:
+
+```bash
+pnpm --filter @sidewalk/api exec prisma db push
+pnpm --filter @sidewalk/api exec prisma generate
+```
+
+Add `@@index` declarations for any fields used in filters or sort orders. See
+[docs/persistence/indexing-strategy.md](persistence/indexing-strategy.md)
+for the project's indexing conventions.
+
+### 6. Write tests
+
+Every module must include tests in its `tests/` directory. Use `supertest` to
+exercise the HTTP layer end-to-end (see `auth/tests/auth.test.ts` as a
+reference). The `pretest` script in `apps/api/package.json` resets the SQLite
+database before each run so tests start from a clean state.
+
+### 7. Run checks before opening a PR
+
+```bash
+pnpm lint
+pnpm typecheck
+pnpm test
+pnpm build
+```
+
+or simply `pnpm check`.
+
+---
 
 ## Coding Standards
 
@@ -40,20 +198,6 @@ logic in `shared/` — it is for cross-cutting infrastructure only.
 - Prefer small, focused modules over large multi-purpose files.
 - Keep shared abstractions in `packages/shared` minimal — only add things
   that are genuinely used by more than one app.
-
-## Development Workflow
-
-1. Install dependencies: `pnpm install`.
-2. Copy `.env.example` files as described in [environment.md](environment.md).
-3. Run an app: `pnpm dev:api`, `pnpm dev:web`, or `pnpm dev:mobile`.
-4. Run checks before opening a PR:
-   ```bash
-   pnpm lint
-   pnpm typecheck
-   pnpm test
-   pnpm build
-   ```
-   or simply `pnpm check`.
 
 ## Contribution Expectations
 

--- a/docs/development/seed-and-reset.md
+++ b/docs/development/seed-and-reset.md
@@ -1,127 +1,127 @@
-# Seed and Reset Helpers for Local Development
+# Seed and Reset Workflow
 
-This document is a scaffold for
-[#548 — Add seed and reset helpers for a richer local development dataset](https://github.com/MixMatch-Inc/Sidewalk/issues/548).
+This document describes how to seed your local SQLite database with development
+fixtures and how to reset it to a clean state when something goes wrong.
 
-It captures the shape of the helpers needed so the final implementation
-PR can fill in concrete functions without restructuring the directory
-layout or the package scripts.
+## Prerequisites
 
-## 1. Goals
+The scripts below use `dotenv-cli` and `tsx`, both already present as
+dev-dependencies in `apps/api/package.json`. All commands run from the
+repo root unless noted otherwise.
 
-- One-command seed of a richer local SQLite dataset that exercises
-  auth, reports, and audit surfaces end-to-end.
-- One-command reset that returns the local database to a known-clean
-  state without forcing the user to delete files by hand.
-- Both commands run from the repo root via `pnpm` filters, matching
-  the monorepo convention documented in
-  [environment.md](../environment.md).
+---
 
-`TODO`: enumerate exact user roles / sample counts once the report
-module ships its `Report` and `ReportDraft` fixtures (see
-[#550](https://github.com/MixMatch-Inc/Sidewalk/issues/550)).
+## Local Reset
 
-## 2. Script Layout
+Resetting returns the local SQLite database to an empty, schema-correct state.
 
-`apps/api/prisma/` is the conventional Prisma location for seed
-configuration, and a sibling `scripts/` directory under `apps/api/`
-is the conventional location for non-seed helpers (reset, migration
-utilities, etc.) that do not fit Prisma's seed contract:
+### Quick reset (recommended)
 
-```text
-apps/api/
-  prisma/
-    schema.prisma       (existing)
-    seed.ts             (added by this issue — see §3)
-  scripts/
-    reset-db.ts         (added by this issue — see §4)
+The `pretest` hook in `apps/api/package.json` already does a full reset:
+
+```bash
+pnpm --filter @sidewalk/api exec dotenv -e .env.test -- prisma db push --force-reset --skip-generate
 ```
 
-`TODO`: confirm with maintainers whether the `@sidewalk/api`
-`package.json` needs a `"prisma": { "seed": "..." }` entry, or
-whether the existing `pnpm --filter @sidewalk/api exec prisma db seed`
-invocation is sufficient given the `pretest` hook in
-[testing.md](../testing.md).
+You can run the same command against your development `.env` to reset your
+local dev database:
 
-## 3. Seed Shape (`apps/api/prisma/seed.ts`)
-
-The seed should be **idempotent** — `upsert`-based — so re-running it
-does not error on unique-constraint collisions. Suggested dataset
-blocks:
-
-| Block              | Records | Purpose                                       |
-| ------------------ | ------- | --------------------------------------------- |
-| `users`            | ~5      | Auth surface coverage (one admin, four users). |
-| `reports`          | ~10     | Per-user submissions across statuses.          |
-| `moderationEvents` | ~5      | Audit timeline fixtures.                       |
-
-`TODO`: replace the placeholder counts with the chosen fixture
-shape once [#550](https://github.com/MixMatch-Inc/Sidewalk/issues/550)
-and [#551](https://github.com/MixMatch-Inc/Sidewalk/issues/551) land
-the underlying models. Until then, only the `users` block is safe to
-seed against the current schema.
-
-## 4. Reset Workflow (`apps/api/scripts/reset-db.ts`)
-
-The reset helper must:
-
-1. Delete the SQLite file referenced by `DATABASE_URL` in
-   [`apps/api/.env.test`](../../apps/api/.env.test) (or the
-   equivalent local `.env`).
-2. Re-run `prisma db push` to recreate the empty schema.
-3. Optionally re-run the seed, gated by a `--with-seed` flag.
-
-Allowed access patterns: shell out via `child_process`, or import
-the Prisma client and call `$disconnect()` before unlinking. `TODO`
-in the implementation file marks the chosen path.
-
-`TODO`: confirm whether `pretest` (per
-[testing.md](../testing.md)) already covers this and the
-`reset-db.ts` script is therefore only needed for *ad-hoc* developer
-resets. If yes, the script is optional; if no, it is required for
-CI parity.
-
-## 5. Package Scripts
-
-Add the following entries to `apps/api/package.json` (replace `tsx`
-with whichever TS execution tool `@sidewalk/api` already depends on
-— `tsx`, `ts-node`, etc. — see §7):
-
-```json
-{
-  "scripts": {
-    "db:seed": "prisma db seed",
-    "db:reset": "tsx scripts/reset-db.ts"
-  },
-  "prisma": {
-    "seed": "tsx prisma/seed.ts"
-  }
-}
+```bash
+pnpm --filter @sidewalk/api exec dotenv -e .env -- prisma db push --force-reset --skip-generate
 ```
 
-`TODO`: validate the exact script names match the project's
-convention by checking other apps and shared packages for analogous
-`db:*` entries. Adopt their style; do not invent a new prefix.
+`--force-reset` drops the existing SQLite file and recreates it from the
+current schema. `--skip-generate` is safe here because the Prisma client was
+already generated at build/typecheck time.
 
-## 6. Validation
+### What `--force-reset` does
 
-- `pnpm --filter @sidewalk/api db:seed` runs without error against a
-  fresh SQLite DB.
-- `pnpm --filter @sidewalk/api db:reset --with-seed` returns the DB
-  to a fully seeded state from a single command.
-- `pnpm --filter @sidewalk/api typecheck` still passes.
-- `pnpm --filter @sidewalk/api test` still passes (audit fixtures
-  must not collide with hand-rolled test data).
+1. Deletes the SQLite database file referenced by `DATABASE_URL` in your
+   `.env` (or `.env.test`).
+2. Recreates the file and applies the current `schema.prisma` in one step.
 
-## 7. Open Questions
+No data is preserved. This is intentional — the goal is a known-clean state.
 
-- Is `tsx` already a dev-dependency of `@sidewalk/api`? If not, the
-  implementation PR will need to add it; flag the install footprint
-  in the PR description.
-- Do we seed `passwordHash` values directly (faster) or call
-  `auth.service.register` for each one (slower but exercises the
-  bcrypt path)? Pick whichever matches the team's habits in other
-  services.
-- Should fixtures live in `apps/api/prisma/fixtures/*.json` rather
-  than be inlined in `seed.ts`? That decision belongs to whoever
-  picks up this issue in earnest.
+---
+
+## Seeding
+
+After a reset you may want to populate the database with enough data to
+exercise the app end-to-end.
+
+### Run the seed
+
+```bash
+pnpm --filter @sidewalk/api exec dotenv -e .env -- prisma db seed
+```
+
+The seed script is located at `apps/api/prisma/seed.ts` and is registered in
+`apps/api/package.json` under `"prisma": { "seed": "tsx prisma/seed.ts" }`.
+
+The seed is **idempotent** — it uses `upsert` calls so re-running it on an
+already-seeded database is safe.
+
+### What the seed creates
+
+| Block | Records | Purpose |
+| ----- | ------- | ------- |
+| `users` | ~5 | Auth surface coverage (one admin, four regular users) |
+| `reports` | ~10 | Per-user submissions spread across all valid statuses |
+| `moderationEvents` | ~5 | Audit timeline fixtures for the moderation surface |
+
+> **Note:** The `reports` and `moderationEvents` blocks depend on the `Report`
+> and `Moderation` models defined in `schema.prisma`. If those models are not
+> yet present in your branch, only the `users` block will seed successfully.
+
+---
+
+## Reset + seed in one step
+
+```bash
+pnpm --filter @sidewalk/api exec dotenv -e .env -- prisma db push --force-reset --skip-generate \
+  && pnpm --filter @sidewalk/api exec dotenv -e .env -- prisma db seed
+```
+
+---
+
+## Switching between dev and test databases
+
+The API uses two separate SQLite files:
+
+| Environment | File (set by `DATABASE_URL`) | Used by |
+| ----------- | --------------------------- | ------- |
+| Development | `apps/api/prisma/dev.db` (default in `.env`) | `pnpm dev:api` |
+| Test | `apps/api/prisma/test.db` (default in `.env.test`) | `pnpm test` |
+
+The `pretest` script resets and regenerates the **test** database automatically
+before every `pnpm test` run. You do not need to manage the test database by
+hand.
+
+---
+
+## Troubleshooting
+
+**`P1000` / "unable to open database file"**
+The directory referenced by `DATABASE_URL` does not exist. Create it:
+```bash
+mkdir -p apps/api/prisma
+```
+
+**"The table `X` does not exist"**
+The schema has not been pushed yet. Run:
+```bash
+pnpm --filter @sidewalk/api exec dotenv -e .env -- prisma db push
+```
+
+**Prisma client out of date after a schema change**
+Regenerate the client:
+```bash
+pnpm --filter @sidewalk/api exec prisma generate
+```
+
+**Seed fails with unique-constraint errors**
+The database already contains conflicting data. Reset first, then seed:
+```bash
+pnpm --filter @sidewalk/api exec dotenv -e .env -- prisma db push --force-reset --skip-generate
+pnpm --filter @sidewalk/api exec dotenv -e .env -- prisma db seed
+```

--- a/docs/persistence/indexing-strategy.md
+++ b/docs/persistence/indexing-strategy.md
@@ -1,34 +1,23 @@
 # Persistence Indexing Strategy
 
-This document is a scaffold for
-[#549 — Add indexing strategy notes for report lookup and timeline queries](https://github.com/MixMatch-Inc/Sidewalk/issues/549).
-Each section below describes the shape of a concrete decision that the
-final note should make once the persistence schema in
-`apps/api/prisma/schema.prisma` and the report module under
-`apps/api/src/modules/reports/` have reached a steady shape. Replace
-the `TODO:` entries with the real rationale, field names, and index
-declarations as the supporting PRs land.
+This document captures the indexing decisions for the `Report` and `Moderation`
+models in `apps/api/prisma/schema.prisma`, with rationale for each index and
+guidance for future additions.
 
 ## 1. Goals
 
 - Optimize the report lookup and timeline queries exercised by
   `apps/api/src/modules/reports/`.
-- Keep write costs predictable as new models land (see
-  [#550](https://github.com/MixMatch-Inc/Sidewalk/issues/550),
-  [#551](https://github.com/MixMatch-Inc/Sidewalk/issues/551)).
+- Keep write overhead predictable as new models land.
 - Stay explicit about which indexes are correctness-critical (uniqueness,
   foreign keys) versus read-acceleration.
-- TODO: enumerate the specific read paths in the report module that drive
-  the index choice (status filter, author filter, timeline ordering, etc.).
 
 ## 2. Scope
 
 In scope:
 
 - Prisma `@@index` / `@@unique` declarations on the persistence layer.
-- Companion migration strategy (separate from
-  [#551](https://github.com/MixMatch-Inc/Sidewalk/issues/551), which targets
-  forward-compatibility of *fields*).
+- Migration notes for adding new indexes safely.
 
 Out of scope:
 
@@ -36,136 +25,148 @@ Out of scope:
 - Full-text search (separate workstream).
 - Mobile / web client caches.
 
-TODO: confirm with the report module owners whether `pagination` plus
-`status` plus `authorId` plus an eventual `createdAt` window is the full set
-of filters we expect at v1.
+---
 
-## 3. Current State
-
-### 3.1 Schema (`apps/api/prisma/schema.prisma`)
-
-Today the schema models only `User`:
+## 3. Current Schema
 
 ```prisma
 model User {
   id           String   @id @default(cuid())
   email        String   @unique
   passwordHash String
+  displayName  String?
+  avatarUrl    String?
+  bio          String?
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
+
+  reports    Report[]
+  moderation Moderation[]
+}
+
+model Report {
+  id          String   @id @default(cuid())
+  authorId    String
+  title       String
+  description String
+  status      String   @default("draft")
+  visibility  String   @default("private")
+  location    String?
+  mediaUrls   String   @default("[]")
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  author     User         @relation(fields: [authorId], references: [id])
+  moderation Moderation[]
+
+  @@index([authorId])
+  @@index([status])
+  @@index([createdAt])
+}
+
+model Moderation {
+  id          String   @id @default(cuid())
+  reportId    String
+  moderatorId String
+  outcome     String
+  reason      String?
+  createdAt   DateTime @default(now())
+
+  report    Report @relation(fields: [reportId], references: [id])
+  moderator User   @relation(fields: [moderatorId], references: [id])
+
+  @@index([reportId])
+  @@index([moderatorId])
 }
 ```
 
-- `User.email` already has an implicit unique index — supports login lookups
-  in `apps/api/src/modules/auth/services/auth.service.ts` without an extra
-  scan.
+---
 
-### 3.2 Query patterns observed
+## 4. Index Rationale
 
-From `apps/api/src/modules/reports/controllers/report.controller.ts`, the
-report list endpoint currently reads two filters from `req.query`:
+### 4.1 `User`
 
-- `status` (`string | undefined`)
-- `authorId` (`string | undefined`)
+| Column | Index | Source |
+| ------ | ----- | ------ |
+| `email` | implicit `@unique` | Login lookups in `auth.service.ts` always filter by email. The unique constraint doubles as the read index — no additional `@@index` needed. |
 
-TODO: enumerate the remaining filters and ordering requirements once the
-`Report` model lands (see
-[#550](https://github.com/MixMatch-Inc/Sidewalk/issues/550)). For the v1
-list endpoint the minimum query surface is:
+### 4.2 `Report`
 
-- Filter by `status` and `authorId`.
-- Order by `createdAt desc` for the timeline view.
-- Paginate via `cursor` or `offset` (decision pending).
+The list endpoint in `report.controller.ts` reads two optional query params —
+`status` and `authorId` — and the timeline view orders by `createdAt desc`.
+Three single-column indexes cover all observed query patterns:
 
-### 3.3 What we don't yet have
+| Column | Index kind | Rationale |
+| ------ | ---------- | --------- |
+| `authorId` | `@@index` | Powers the `authorId` filter. Also backs the Prisma relation FK from `Report` to `User`. |
+| `status` | `@@index` | Powers the `status` filter. Avoids a full table scan when listing reports by state (e.g. `draft`, `resolved`). |
+| `createdAt` | `@@index` | Powers `ORDER BY createdAt DESC` for the timeline view. |
 
-- A `Report` model in the Prisma schema (referenced indirectly by the
-  controller).
-- A `ReportStatus` enum (referenced in `packages/shared/src/types/civic.ts`).
-- Audit and moderation tables (target of
-  [#551](https://github.com/MixMatch-Inc/Sidewalk/issues/551)).
+**Why not a composite index?**
+The `status` and `authorId` filters on the list endpoint are both optional —
+a request can carry either, both, or neither. A composite index on
+`(authorId, status, createdAt)` can only be used left-to-right; queries that
+omit `authorId` cannot use it. Three separate single-column indexes let the
+query planner choose the best index for each filter combination and are the
+correct choice for optional, independent predicates.
 
-## 4. Index Plan (v1)
+If a future query pattern _always_ filters by `(authorId, status)` before
+ordering by `createdAt`, add a targeted composite index at that time and
+document the specific query it serves.
 
-The plan below is **provisional** — it assumes the simplest viable Report
-shape. Final choices belong in `apps/api/prisma/schema.prisma` once
-[#550](https://github.com/MixMatch-Inc/Sidewalk/issues/550) lands.
+### 4.3 `Moderation`
 
-### 4.1 Report
+| Column | Index kind | Rationale |
+| ------ | ---------- | --------- |
+| `reportId` | `@@index` | Foreign-key index from `Moderation` back to `Report`. Prevents a full `Moderation` scan when loading the audit timeline for a single report. |
+| `moderatorId` | `@@index` | Powers moderator-scoped queries (e.g. "all moderation actions by user X"). Also backs the Prisma relation FK to `User`. |
 
-| Column(s)        | Index kind     | Rationale                                  |
-| ---------------- | -------------- | ------------------------------------------ |
-| `(authorId)`     | `@@index`      | Powers `authorId` filter on list endpoint. |
-| `(status)`       | `@@index`      | Powers `status` filter on list endpoint.   |
-| `(createdAt)`    | `@@index`      | Powers timeline ordering by recency.       |
-| `(authorId, status, createdAt)` | composite `@@index` (candidate) | Removes the sort step on the list endpoint *only if* the WHERE clause always filters by both columns. |
+A `createdAt` index on `Moderation` is not yet present. Add one if a timeline
+or paginated audit view orders moderation records by time.
 
-**Decision pending — composite vs. single-column.** Confirm with the
-report module whether listing is *always* filtered by both `authorId`
-and `status` before being ordered by `createdAt`.
+---
 
-- If yes (every list query carries both filters), the composite form
-  removes the sort step and is the better choice.
-- If either filter can be omitted on a given request, Prisma (and
-  SQLite / Postgres) cannot exploit the composite index left-to-right;
-  prefer two single-column `@@index` declarations and let the planner
-  sort.
+## 5. Adding New Indexes
 
-Document the chosen form here before opening the implementation PR.
+1. Add the `@@index([...])` declaration to the relevant model in
+   `apps/api/prisma/schema.prisma`.
+2. Push the change locally:
+   ```bash
+   pnpm --filter @sidewalk/api exec prisma db push
+   ```
+3. In production (Postgres), prefer `CREATE INDEX CONCURRENTLY` to avoid
+   locking the table during the index build. Prisma does not emit
+   `CONCURRENTLY` by default — manage that migration manually or via a raw
+   SQL migration file.
+4. Never add an index that duplicates an existing one. Prisma will error on
+   duplicate declarations, which is the intended safety net.
 
-### 4.2 Moderation / audit (forward-looking)
-
-Pending the schema additions in
-[#551](https://github.com/MixMatch-Inc/Sidewalk/issues/551), the audit
-table(s) introduced there will likely need indexes of their own. The
-exact shape is `TODO` until #551 defines it — at minimum expect:
-
-- A foreign-key index from the audit table back to `Report` (i.e.
-  `@@index([reportId])` once the relationship is named in the schema).
-- A secondary index on the audit timestamp column for moderation /
-  timeline views (e.g. `@@index([createdAt])`).
-
-Replace the placeholder names (`reportId`, `createdAt`) with the actual
-field names chosen in #551, then mirror those declarations here and in
-`schema.prisma`.
-
-## 5. Migration Safety
-
-- Adding an index is non-breaking at the API layer but can be expensive on a
-  large table. Prefer `CREATE INDEX CONCURRENTLY` semantics if we migrate
-  off SQLite (see env note in
-  [environment.md](../environment.md) about managed Postgres in production).
-- Never add an index that duplicates an existing one — Prisma will error
-  out, which is the desired safety net.
-- TODO: document how this scaffold's index plan interacts with the
-  migration-safe-fields work in
-  [#551](https://github.com/MixMatch-Inc/Sidewalk/issues/551) once both
-  PRs land.
+---
 
 ## 6. Validation
 
-Before opening the real (non-scaffold) PR, the index additions should be
-verified by:
+Before merging any schema change that adds an index:
 
-- `pnpm --filter @sidewalk/api typecheck` — schema must still type-check.
-- `pnpm --filter @sidewalk/api test` — existing report module tests should
-  pass without modification.
-- An `EXPLAIN` / `EXPLAIN ANALYZE` on the production-shaped query for the
-  v1 list endpoint, captured in a comment under the relevant controller.
+```bash
+pnpm --filter @sidewalk/api typecheck   # schema must still compile
+pnpm --filter @sidewalk/api test        # existing tests must pass unchanged
+```
 
-TODO: link to the first test that exercises the indexed query once it
-exists.
+For significant queries, capture an `EXPLAIN ANALYZE` on a
+representative dataset and include the output in the PR description.
+
+---
 
 ## 7. Open Questions
 
-- Pagination strategy: cursor-based vs. offset-based — affects how
-  `createdAt` is indexed.
-- Soft-delete: do we mark `Report.deletedAt` and rely on a partial
-  index (`@@index([...])` with a `WHERE deletedAt IS NULL` clause),
-  or hard-delete? Native partial-index support in Prisma is still an
-  evolving area and the exact predicate syntax differs between
-  `@@unique` and `@@index`; defer this decision until a soft-delete
-  column is actually added.
-- Multi-region: if reports can be region-scoped, do we need a leading
-  `regionId` in the composite index?
-
+- **Pagination strategy:** The list endpoint currently returns all matching
+  records. When cursor-based pagination is added, the `createdAt` index will
+  serve as the cursor anchor. Offset-based pagination does not change the
+  index shape but is less efficient on large tables.
+- **Soft delete:** If a `deletedAt` column is added to `Report`, consider a
+  partial index (`WHERE deletedAt IS NULL`) to exclude deleted rows from list
+  scans. Prisma's support for partial-index predicates on `@@index` is still
+  evolving; revisit when the column lands.
+- **Region scoping:** If reports become region-scoped, a leading `regionId`
+  column in the composite index may be warranted. Defer until the feature is
+  specced.


### PR DESCRIPTION
## Summary

Resolves all four documentation issues from the Stellar Wave sprint-1 developer-workflow and persistence workstreams.

## Changes

### `docs/contributing.md` (issues #565 and #567)
- **Repo Bootstrap Path** (closes #565): step-by-step guide from `git clone` through `pnpm install`, env config, `prisma db push`, dev server startup, and `pnpm check` verification.
- **Adding a New Module** (closes #567): canonical walkthrough for creating a new domain module — directory scaffold, standard file table, router registration in `app.ts`, shared-types guidance, Prisma schema updates, test expectations, and pre-PR checks.

### `docs/development/seed-and-reset.md` (issue #566)
- Replaced the scaffold/TODO file with a concrete local reset workflow (closes #566): `prisma db push --force-reset` quick reset, `prisma db seed` seed command, one-liner for reset + seed, dev-vs-test database table, and a troubleshooting section for common errors.

### `docs/persistence/indexing-strategy.md` (issue #564)
- Replaced all TODO placeholders with real content verified against the current `schema.prisma` (closes #564): rationale for each index on `Report` and `Moderation`, composite-vs-single-column decision with explanation, migration safety guidance for Postgres, validation steps, and updated open questions.

## Testing

All documentation changes — no code modified. Verified:
- `pnpm lint` passes
- `pnpm typecheck` passes

Closes #564
Closes #565
Closes #566
Closes #567