### PR TITLE
feat(cases): civic case watchlist service & follow-up UI panel

### DIFF
--- a/apps/api/src/modules/cases/services/civic-watchlist.service.ts
+++ b/apps/api/src/modules/cases/services/civic-watchlist.service.ts
@@ -1,0 +1,29 @@
+import {
+  watchlistSummarySchema,
+  type CivicWatchlistItem,
+  type WatchlistSummary,
+} from '@qyou/shared';
+
+export class CivicWatchlistService {
+  private readonly watchlists: Map<string, CivicWatchlistItem[]> = new Map();
+
+  public getWatchlist(userId: string): WatchlistSummary {
+    const items = this.watchlists.get(userId) ?? [];
+    const activeCount = items.filter((i) => i.followUpStatus === 'active_review' || i.followUpStatus === 'pending_city_response').length;
+
+    const summary: WatchlistSummary = {
+      userId,
+      totalCasesWatched: items.length,
+      activeFollowUpsCount: activeCount,
+      items,
+    };
+
+    return watchlistSummarySchema.parse(summary);
+  }
+
+  public addToWatchlist(userId: string, item: CivicWatchlistItem): void {
+    const list = this.watchlists.get(userId) ?? [];
+    list.push(item);
+    this.watchlists.set(userId, list);
+  }
+}

--- a/apps/web/src/components/CivicCaseWatchlistPanel.tsx
+++ b/apps/web/src/components/CivicCaseWatchlistPanel.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import type { CivicWatchlistItem } from '@qyou/shared';
+
+interface CivicCaseWatchlistPanelProps {
+  items?: CivicWatchlistItem[];
+  onRemoveItem?: (caseId: string) => void;
+}
+
+export function CivicCaseWatchlistPanel({ items = [], onRemoveItem }: CivicCaseWatchlistPanelProps) {
+  return (
+    <div style={{ padding: '20px', background: '#ffffff', border: '1px solid #e2e8f0', borderRadius: '12px' }}>
+      <h3 style={{ margin: '0 0 16px 0', fontSize: '16px', color: '#0f172a' }}>Watched Civic Cases</h3>
+      {items.length === 0 ? (
+        <p style={{ fontSize: '13px', color: '#64748b' }}>No civic cases currently added to your watchlist.</p>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+          {items.map((item) => (
+            <div key={item.caseId} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '12px', background: '#f8fafc', borderRadius: '8px' }}>
+              <div>
+                <div style={{ fontSize: '14px', fontWeight: 'bold', color: '#1e293b' }}>{item.title}</div>
+                <div style={{ fontSize: '12px', color: '#64748b' }}>📍 {item.neighborhood} | Category: {item.category}</div>
+              </div>
+              {onRemoveItem && (
+                <button onClick={() => onRemoveItem(item.caseId)} style={{ padding: '4px 8px', background: '#fee2e2', color: '#991b1b', border: 'none', borderRadius: '4px', cursor: 'pointer', fontSize: '12px' }}>
+                  Unwatch
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/docs/civic-case-watchlist-followup-guide.md
+++ b/docs/civic-case-watchlist-followup-guide.md
@@ -1,0 +1,14 @@
+# Civic Case Watchlist & Follow-up Guide
+
+This document specifies the civic case watch list management, status indicators, and subscriber UI panels in Sidewalk.
+
+## Architecture & Services
+
+1. **Watchlist Service**:
+   - `apps/api/src/modules/cases/services/civic-watchlist.service.ts`: `CivicWatchlistService` tracking user case watchlists and follow-up activities.
+
+2. **Web Watchlist Component**:
+   - `CivicCaseWatchlistPanel`: React UI component displaying active watched cases and unwatch actions.
+
+3. **Validation Schemas & Interfaces**:
+   - `civicWatchlistItemSchema` and `CivicWatchlistItem` defined in `@qyou/shared`.

--- a/packages/shared/src/types/civic-watchlist.types.ts
+++ b/packages/shared/src/types/civic-watchlist.types.ts
@@ -1,0 +1,20 @@
+export type CaseFollowUpStatus = 'active_review' | 'pending_city_response' | 'resolved' | 'stale';
+export type PriorityLevel = 'high' | 'medium' | 'low';
+
+export interface CivicWatchlistItem {
+  caseId: string;
+  title: string;
+  neighborhood: string;
+  category: string;
+  followUpStatus: CaseFollowUpStatus;
+  priority: PriorityLevel;
+  lastActivityAtIso: string;
+  addedAtIso: string;
+}
+
+export interface WatchlistSummary {
+  userId: string;
+  totalCasesWatched: number;
+  activeFollowUpsCount: number;
+  items: CivicWatchlistItem[];
+}

--- a/packages/shared/src/validation/civic-watchlist.schemas.ts
+++ b/packages/shared/src/validation/civic-watchlist.schemas.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+export const caseFollowUpStatusSchema = z.enum([
+  'active_review',
+  'pending_city_response',
+  'resolved',
+  'stale',
+]);
+
+export const priorityLevelSchema = z.enum(['high', 'medium', 'low']);
+
+export const civicWatchlistItemSchema = z.object({
+  caseId: z.string().min(1, 'Case ID is required.'),
+  title: z.string().min(1, 'Case title is required.'),
+  neighborhood: z.string().min(1),
+  category: z.string().min(1),
+  followUpStatus: caseFollowUpStatusSchema,
+  priority: priorityLevelSchema.default('medium'),
+  lastActivityAtIso: z.string().min(1),
+  addedAtIso: z.string().min(1),
+});
+
+export const watchlistSummarySchema = z.object({
+  userId: z.string().min(1),
+  totalCasesWatched: z.number().int().min(0),
+  activeFollowUpsCount: z.number().int().min(0),
+  items: z.array(civicWatchlistItemSchema),
+});
+
+export type CivicWatchlistItemInput = z.infer<typeof civicWatchlistItemSchema>;
+export type WatchlistSummaryInput = z.infer<typeof watchlistSummarySchema>;


### PR DESCRIPTION
Implemented civic case watchlist tracking services, urgency priority schemas, and dashboard UI panels.

Highlights:
- Created CivicWatchlistService in apps/api/src/modules/cases managing case watchlists
- Added CivicCaseWatchlistPanel React UI component in apps/web/src/components
- Defined civicWatchlistItemSchema & priorityLevelSchema in packages/shared
- Documented watchlist specifications in docs/civic-case-watchlist-followup-guide.md

close #768
close #769
close #770
close #771