### PR TITLE
feat(notifications): quiet hours evaluator service & low-noise digest preferences

### DIFF
--- a/apps/api/src/modules/notifications/services/quiet-hours-evaluator.service.ts
+++ b/apps/api/src/modules/notifications/services/quiet-hours-evaluator.service.ts
@@ -1,0 +1,19 @@
+import {
+  quietHoursScheduleSchema,
+  type QuietHoursScheduleInput,
+} from '@qyou/shared';
+
+export class QuietHoursEvaluatorService {
+  public isCurrentlyInQuietHours(schedule: QuietHoursScheduleInput, currentHour: number): boolean {
+    const validated = quietHoursScheduleSchema.parse(schedule);
+    if (!validated.isEnabled) return false;
+
+    const start = parseInt(validated.startTimeWindow.split(':')[0], 10);
+    const end = parseInt(validated.endTimeWindow.split(':')[0], 10);
+
+    if (start > end) {
+      return currentHour >= start || currentHour < end;
+    }
+    return currentHour >= start && currentHour < end;
+  }
+}

--- a/apps/web/src/components/QuietHoursSettingsCard.tsx
+++ b/apps/web/src/components/QuietHoursSettingsCard.tsx
@@ -1,0 +1,29 @@
+import React, { useState } from 'react';
+
+export function QuietHoursSettingsCard() {
+  const [enabled, setEnabled] = useState(true);
+  const [startTime, setStartTime] = useState('22:00');
+  const [endTime, setEndTime] = useState('07:00');
+
+  return (
+    <div style={{ padding: '20px', background: '#ffffff', border: '1px solid #e2e8f0', borderRadius: '12px' }}>
+      <h3 style={{ margin: '0 0 12px 0', fontSize: '16px', color: '#0f172a' }}>Quiet Hours Preferences</h3>
+      <label style={{ display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer', marginBottom: '16px' }}>
+        <input type="checkbox" checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />
+        <span style={{ fontSize: '14px', color: '#334155' }}>Pause non-urgent community alerts during quiet hours</span>
+      </label>
+      {enabled && (
+        <div style={{ display: 'flex', gap: '16px' }}>
+          <div>
+            <label style={{ display: 'block', fontSize: '12px', color: '#64748b' }}>Start Time</label>
+            <input type="time" value={startTime} onChange={(e) => setStartTime(e.target.value)} style={{ padding: '6px 10px', borderRadius: '6px', border: '1px solid #cbd5e1' }} />
+          </div>
+          <div>
+            <label style={{ display: 'block', fontSize: '12px', color: '#64748b' }}>End Time</label>
+            <input type="time" value={endTime} onChange={(e) => setEndTime(e.target.value)} style={{ padding: '6px 10px', borderRadius: '6px', border: '1px solid #cbd5e1' }} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/docs/notification-quiet-hours-digest-guide.md
+++ b/docs/notification-quiet-hours-digest-guide.md
@@ -1,0 +1,14 @@
+# Quiet Hours & Digest Notification Behavior Guide
+
+This document details the quiet hours evaluation logic, digest interval schedules, and user settings components in Sidewalk.
+
+## Architecture
+
+1. **Quiet Hours Evaluator**:
+   - `apps/api/src/modules/notifications/services/quiet-hours-evaluator.service.ts`: `QuietHoursEvaluatorService` evaluating local hour windows.
+
+2. **Web Settings UI**:
+   - `QuietHoursSettingsCard`: React UI component offering time window selectors and enable/disable toggles.
+
+3. **Validation Schemas & Interfaces**:
+   - `quietHoursScheduleSchema` and `QuietHoursSchedule` defined in `@qyou/shared`.

--- a/packages/shared/src/types/quiet-hours.types.ts
+++ b/packages/shared/src/types/quiet-hours.types.ts
@@ -1,0 +1,14 @@
+export type DigestFrequency = 'daily' | 'weekly' | 'immediate';
+
+export interface QuietHoursSchedule {
+  isEnabled: boolean;
+  startTimeWindow: string; // e.g. "22:00"
+  endTimeWindow: string;   // e.g. "07:00"
+  userTimezone: string;
+}
+
+export interface NotificationQuietRule {
+  userId: string;
+  schedule: QuietHoursSchedule;
+  digestFrequency: DigestFrequency;
+}

--- a/packages/shared/src/validation/quiet-hours.schemas.ts
+++ b/packages/shared/src/validation/quiet-hours.schemas.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export const digestFrequencySchema = z.enum(['daily', 'weekly', 'immediate']);
+
+export const quietHoursScheduleSchema = z.object({
+  isEnabled: z.boolean().default(true),
+  startTimeWindow: z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/, 'Invalid start time format (HH:mm)'),
+  endTimeWindow: z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/, 'Invalid end time format (HH:mm)'),
+  userTimezone: z.string().default('UTC'),
+});
+
+export const notificationQuietRuleSchema = z.object({
+  userId: z.string().min(1, 'User ID is required.'),
+  schedule: quietHoursScheduleSchema,
+  digestFrequency: digestFrequencySchema.default('daily'),
+});
+
+export type QuietHoursScheduleInput = z.infer<typeof quietHoursScheduleSchema>;
+export type NotificationQuietRuleInput = z.infer<typeof notificationQuietRuleSchema>;


### PR DESCRIPTION
Implemented quiet hours evaluation logic, digest schedule schemas, and web settings card components.

Highlights:
- Created QuietHoursEvaluatorService in apps/api/src/modules/notifications evaluating time windows
- Added QuietHoursSettingsCard React UI component in apps/web/src/components
- Defined quietHoursScheduleSchema & digestFrequencySchema in packages/shared
- Documented quiet hours rules in docs/notification-quiet-hours-digest-guide.md

close #707 
close #708 
close #709 
close #710 