### PR TITLE
feat(notifications): in-app toast & banner patterns for real-time status changes

### DIFF
--- a/apps/api/src/modules/notifications/services/realtime-status-broadcaster.service.ts
+++ b/apps/api/src/modules/notifications/services/realtime-status-broadcaster.service.ts
@@ -1,0 +1,25 @@
+import {
+  toastNotificationMessageSchema,
+  type RealtimeStatusPayload,
+} from '@qyou/shared';
+
+export class RealtimeStatusBroadcasterService {
+  public broadcastStatusChange(caseId: string, newStatus: string): RealtimeStatusPayload {
+    const toast = {
+      id: `toast_${Date.now()}`,
+      level: 'info' as const,
+      title: 'Case Status Updated',
+      message: `Case ${caseId} changed status to: ${newStatus}`,
+      autoDismissMs: 5000,
+    };
+
+    const validatedToast = toastNotificationMessageSchema.parse(toast);
+
+    return {
+      caseId,
+      newStatus,
+      updatedAtIso: new Date().toISOString(),
+      toast: validatedToast,
+    };
+  }
+}

--- a/apps/web/src/components/RealtimeStatusToastBannerContainer.tsx
+++ b/apps/web/src/components/RealtimeStatusToastBannerContainer.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import type { ToastNotificationMessage } from '@qyou/shared';
+
+interface RealtimeStatusToastBannerContainerProps {
+  toasts?: ToastNotificationMessage[];
+  onDismiss?: (id: string) => void;
+}
+
+export function RealtimeStatusToastBannerContainer({ toasts = [], onDismiss }: RealtimeStatusToastBannerContainerProps) {
+  if (toasts.length === 0) return null;
+
+  return (
+    <div style={{ position: 'fixed', bottom: '24px', right: '24px', zIndex: 9999, display: 'flex', flexDirection: 'column', gap: '8px' }}>
+      {toasts.map((t) => (
+        <div key={t.id} style={{ background: '#0f172a', color: '#ffffff', padding: '12px 16px', borderRadius: '8px', boxShadow: '0 4px 6px rgba(0,0,0,0.1)', minWidth: '280px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <div>
+            <div style={{ fontWeight: 'bold', fontSize: '13px' }}>{t.title}</div>
+            <div style={{ fontSize: '12px', color: '#94a3b8' }}>{t.message}</div>
+          </div>
+          {onDismiss && (
+            <button onClick={() => onDismiss(t.id)} style={{ background: 'transparent', border: 'none', color: '#94a3b8', cursor: 'pointer', fontSize: '16px' }}>
+              ×
+            </button>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/docs/toast-banner-realtime-status-guide.md
+++ b/docs/toast-banner-realtime-status-guide.md
@@ -1,0 +1,14 @@
+# Real-time Status Toast & Banner Notifications Guide
+
+This document details the toast notification levels, real-time status update payloads, and web container UI components in Sidewalk.
+
+## Architecture
+
+1. **Broadcaster Service**:
+   - `apps/api/src/modules/notifications/services/realtime-status-broadcaster.service.ts`: `RealtimeStatusBroadcasterService` constructing toast payloads.
+
+2. **Web Container UI**:
+   - `RealtimeStatusToastBannerContainer`: React component rendering active toast notifications in bottom-right viewports.
+
+3. **Validation Schemas & Interfaces**:
+   - `toastNotificationMessageSchema` and `ToastNotificationMessage` defined in `@qyou/shared`.

--- a/packages/shared/src/types/toast-banner.types.ts
+++ b/packages/shared/src/types/toast-banner.types.ts
@@ -1,0 +1,25 @@
+export type NotificationLevel = 'info' | 'success' | 'warning' | 'error';
+
+export interface ToastNotificationMessage {
+  id: string;
+  level: NotificationLevel;
+  title: string;
+  message: string;
+  autoDismissMs?: number;
+}
+
+export interface BannerNotificationType {
+  bannerId: string;
+  level: NotificationLevel;
+  heading: string;
+  body: string;
+  actionText?: string;
+  actionUrl?: string;
+}
+
+export interface RealtimeStatusPayload {
+  caseId: string;
+  newStatus: string;
+  updatedAtIso: string;
+  toast: ToastNotificationMessage;
+}

--- a/packages/shared/src/validation/toast-banner.schemas.ts
+++ b/packages/shared/src/validation/toast-banner.schemas.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+export const notificationLevelSchema = z.enum(['info', 'success', 'warning', 'error']);
+
+export const toastNotificationMessageSchema = z.object({
+  id: z.string().min(1, 'Notification ID is required.'),
+  level: notificationLevelSchema,
+  title: z.string().min(1, 'Title is required.'),
+  message: z.string().min(1, 'Message is required.'),
+  autoDismissMs: z.number().int().positive().optional(),
+});
+
+export const bannerNotificationTypeSchema = z.object({
+  bannerId: z.string().min(1),
+  level: notificationLevelSchema,
+  heading: z.string().min(1),
+  body: z.string().min(1),
+  actionText: z.string().optional(),
+  actionUrl: z.string().optional(),
+});
+
+export type ToastNotificationMessageInput = z.infer<typeof toastNotificationMessageSchema>;
+export type BannerNotificationTypeInput = z.infer<typeof bannerNotificationTypeSchema>;


### PR DESCRIPTION
Implemented real-time status change toast broadcasters, notification level schemas, and web UI toast container components.

Highlights:
- Created RealtimeStatusBroadcasterService in apps/api/src/modules/notifications for status change events
- Added RealtimeStatusToastBannerContainer React UI component in apps/web/src/components
- Defined toastNotificationMessageSchema & notificationLevelSchema in packages/shared
- Documented toast & banner patterns in docs/toast-banner-realtime-status-guide.md

close #751
close #752 
close #753 
close #754