### PR TITLE
feat(notifications): alert preview copy explainer service & UI card

### DIFF
--- a/apps/api/src/modules/notifications/services/alert-preview-explainer.service.ts
+++ b/apps/api/src/modules/notifications/services/alert-preview-explainer.service.ts
@@ -1,0 +1,29 @@
+import {
+  alertPreviewPayloadSchema,
+  type AlertPreviewPayload,
+  type ExplainerCopyOptions,
+} from '@qyou/shared';
+
+export class AlertPreviewExplainerService {
+  public generateExplainerPreview(options: ExplainerCopyOptions): AlertPreviewPayload {
+    let explainer = 'You received this notification based on your account activity preferences.';
+    if (options.category === 'report_author') {
+      explainer = `Sent because you created the report: "${options.caseTitle}".`;
+    } else if (options.category === 'subscribed_category') {
+      explainer = `Sent because you subscribed to civic updates for this issue category.`;
+    } else if (options.category === 'neighborhood_proximity') {
+      explainer = `Sent because this activity occurred near ${options.locationName ?? 'your neighborhood'}.`;
+    }
+
+    const payload: AlertPreviewPayload = {
+      previewId: `prev_${Date.now()}`,
+      headline: `Update on ${options.caseTitle}`,
+      bodySnippet: `New progress activity recorded for ${options.caseTitle}.`,
+      explainerCopy: explainer,
+      category: options.category,
+      generatedAtIso: new Date().toISOString(),
+    };
+
+    return alertPreviewPayloadSchema.parse(payload);
+  }
+}

--- a/apps/web/src/components/AlertPreviewExplainerCard.tsx
+++ b/apps/web/src/components/AlertPreviewExplainerCard.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import type { AlertPreviewPayload } from '@qyou/shared';
+
+interface AlertPreviewExplainerCardProps {
+  preview: AlertPreviewPayload;
+}
+
+export function AlertPreviewExplainerCard({ preview }: AlertPreviewExplainerCardProps) {
+  return (
+    <div style={{ padding: '16px', background: '#f8fafc', border: '1px solid #cbd5e1', borderRadius: '8px' }}>
+      <h4 style={{ margin: '0 0 6px 0', fontSize: '14px', color: '#0f172a' }}>{preview.headline}</h4>
+      <p style={{ margin: '0 0 10px 0', fontSize: '13px', color: '#334155' }}>{preview.bodySnippet}</p>
+      <div style={{ padding: '8px 12px', background: '#eff6ff', borderLeft: '3px solid #3b82f6', borderRadius: '4px', fontSize: '12px', color: '#1e40af' }}>
+        ℹ️ <strong>Why you got this alert:</strong> {preview.explainerCopy}
+      </div>
+    </div>
+  );
+}

--- a/docs/notification-preview-copy-explainer-guide.md
+++ b/docs/notification-preview-copy-explainer-guide.md
@@ -1,0 +1,14 @@
+# Notification Preview Copy & Trigger Explainer Guide
+
+This document details the alert preview generator logic, trigger reason categories, and explainer UI cards in Sidewalk.
+
+## Architecture
+
+1. **Explainer Service**:
+   - `apps/api/src/modules/notifications/services/alert-preview-explainer.service.ts`: `AlertPreviewExplainerService` formatting human-readable trigger explainers.
+
+2. **Web Explainer UI**:
+   - `AlertPreviewExplainerCard`: React component displaying alert preview text alongside trigger rationale callouts.
+
+3. **Validation Schemas & Interfaces**:
+   - `alertPreviewPayloadSchema` and `AlertPreviewPayload` defined in `@qyou/shared`.

--- a/packages/shared/src/types/alert-preview-explainer.types.ts
+++ b/packages/shared/src/types/alert-preview-explainer.types.ts
@@ -1,0 +1,16 @@
+export type TriggerReasonCategory = 'report_author' | 'subscribed_category' | 'neighborhood_proximity' | 'community_mention';
+
+export interface ExplainerCopyOptions {
+  category: TriggerReasonCategory;
+  caseTitle: string;
+  locationName?: string;
+}
+
+export interface AlertPreviewPayload {
+  previewId: string;
+  headline: string;
+  bodySnippet: string;
+  explainerCopy: string;
+  category: TriggerReasonCategory;
+  generatedAtIso: string;
+}

--- a/packages/shared/src/validation/alert-preview-explainer.schemas.ts
+++ b/packages/shared/src/validation/alert-preview-explainer.schemas.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export const triggerReasonCategorySchema = z.enum([
+  'report_author',
+  'subscribed_category',
+  'neighborhood_proximity',
+  'community_mention',
+]);
+
+export const alertPreviewPayloadSchema = z.object({
+  previewId: z.string().min(1, 'Preview ID is required.'),
+  headline: z.string().min(1),
+  bodySnippet: z.string().min(1),
+  explainerCopy: z.string().min(1),
+  category: triggerReasonCategorySchema,
+  generatedAtIso: z.string().min(1),
+});
+
+export type AlertPreviewPayloadInput = z.infer<typeof alertPreviewPayloadSchema>;


### PR DESCRIPTION
Implemented alert preview copy explainers, trigger rationale categories, and notification preview UI cards.

Highlights:
- Created AlertPreviewExplainerService in apps/api/src/modules/notifications generating trigger rationale
- Added AlertPreviewExplainerCard React UI component in apps/web/src/components
- Defined alertPreviewPayloadSchema & triggerReasonCategorySchema in packages/shared
- Documented preview copy guidelines in docs/notification-preview-copy-explainer-guide.md

close #747
close #748
close #749
close #750 