### PR TITLE
feat(reports): report thread lifecycle trigger rules & badge UI

### DIFF
--- a/apps/api/src/modules/reports/services/report-lifecycle-trigger.service.ts
+++ b/apps/api/src/modules/reports/services/report-lifecycle-trigger.service.ts
@@ -1,0 +1,30 @@
+import {
+  lifecycleTriggerEvaluationPayloadSchema,
+  type LifecycleTriggerEvaluationPayload,
+  type ReportLifecycleStage,
+} from '@qyou/shared';
+
+export class ReportLifecycleTriggerService {
+  public evaluateTransition(
+    reportId: string,
+    previousStage: ReportLifecycleStage,
+    newStage: ReportLifecycleStage
+  ): LifecycleTriggerEvaluationPayload {
+    const isUrgent = newStage === 'resolved' || newStage === 'work_scheduled';
+
+    const payload: LifecycleTriggerEvaluationPayload = {
+      reportId,
+      previousStage,
+      newStage,
+      ruleApplied: {
+        stage: newStage,
+        notifyAuthor: true,
+        notifySubscribers: true,
+        requiresUrgentAlert: isUrgent,
+      },
+      evaluatedAtIso: new Date().toISOString(),
+    };
+
+    return lifecycleTriggerEvaluationPayloadSchema.parse(payload);
+  }
+}

--- a/apps/web/src/components/ReportLifecycleTriggerBadge.tsx
+++ b/apps/web/src/components/ReportLifecycleTriggerBadge.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import type { ReportLifecycleStage } from '@qyou/shared';
+
+interface ReportLifecycleTriggerBadgeProps {
+  stage?: ReportLifecycleStage;
+}
+
+export function ReportLifecycleTriggerBadge({ stage = 'submitted' }: ReportLifecycleTriggerBadgeProps) {
+  const getBadgeColor = (s: ReportLifecycleStage) => {
+    switch (s) {
+      case 'resolved': return { bg: '#dcfce7', text: '#15803d' };
+      case 'work_scheduled': return { bg: '#e0f2fe', text: '#0369a1' };
+      case 'under_investigation': return { bg: '#fef3c7', text: '#b45309' };
+      default: return { bg: '#f1f5f9', text: '#475569' };
+    }
+  };
+
+  const style = getBadgeColor(stage);
+
+  return (
+    <span style={{ padding: '4px 10px', borderRadius: '12px', background: style.bg, color: style.text, fontSize: '12px', fontWeight: 'bold', textTransform: 'uppercase' }}>
+      {stage.replace('_', ' ')}
+    </span>
+  );
+}

--- a/docs/report-lifecycle-trigger-rules-guide.md
+++ b/docs/report-lifecycle-trigger-rules-guide.md
@@ -1,0 +1,14 @@
+# Report Thread Lifecycle Trigger Rules Guide
+
+This document specifies the lifecycle stage transition trigger rules, subscriber notification conditions, and web badge UI components in Sidewalk.
+
+## Architecture
+
+1. **Lifecycle Trigger Service**:
+   - `apps/api/src/modules/reports/services/report-lifecycle-trigger.service.ts`: `ReportLifecycleTriggerService` evaluating stage transition rules.
+
+2. **Web Badge Component**:
+   - `ReportLifecycleTriggerBadge`: React component rendering report status transition badges.
+
+3. **Validation Schemas & Interfaces**:
+   - `lifecycleTriggerEvaluationPayloadSchema` and `ReportLifecycleStage` defined in `@qyou/shared`.

--- a/packages/shared/src/types/report-lifecycle-triggers.types.ts
+++ b/packages/shared/src/types/report-lifecycle-triggers.types.ts
@@ -1,0 +1,16 @@
+export type ReportLifecycleStage = 'submitted' | 'under_investigation' | 'work_scheduled' | 'resolved' | 'archived';
+
+export interface TriggerRuleCondition {
+  stage: ReportLifecycleStage;
+  notifyAuthor: boolean;
+  notifySubscribers: boolean;
+  requiresUrgentAlert: boolean;
+}
+
+export interface LifecycleTriggerEvaluationPayload {
+  reportId: string;
+  previousStage: ReportLifecycleStage;
+  newStage: ReportLifecycleStage;
+  ruleApplied: TriggerRuleCondition;
+  evaluatedAtIso: string;
+}

--- a/packages/shared/src/validation/report-lifecycle-triggers.schemas.ts
+++ b/packages/shared/src/validation/report-lifecycle-triggers.schemas.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+export const reportLifecycleStageSchema = z.enum([
+  'submitted',
+  'under_investigation',
+  'work_scheduled',
+  'resolved',
+  'archived',
+]);
+
+export const triggerRuleConditionSchema = z.object({
+  stage: reportLifecycleStageSchema,
+  notifyAuthor: z.boolean().default(true),
+  notifySubscribers: z.boolean().default(true),
+  requiresUrgentAlert: z.boolean().default(false),
+});
+
+export const lifecycleTriggerEvaluationPayloadSchema = z.object({
+  reportId: z.string().min(1, 'Report ID is required.'),
+  previousStage: reportLifecycleStageSchema,
+  newStage: reportLifecycleStageSchema,
+  ruleApplied: triggerRuleConditionSchema,
+  evaluatedAtIso: z.string().min(1),
+});
+
+export type TriggerRuleConditionInput = z.infer<typeof triggerRuleConditionSchema>;
+export type LifecycleTriggerEvaluationPayloadInput = z.infer<typeof lifecycleTriggerEvaluationPayloadSchema>;


### PR DESCRIPTION
Implemented report thread lifecycle stage transitions, trigger rule condition schemas, and UI status badges.

Highlights:
- Created ReportLifecycleTriggerService in apps/api/src/modules/reports evaluating transition rules
- Added ReportLifecycleTriggerBadge React UI component in apps/web/src/components
- Defined lifecycleTriggerEvaluationPayloadSchema & triggerRuleConditionSchema in packages/shared
- Documented trigger rules in docs/report-lifecycle-trigger-rules-guide.md

close #703
close #704
close #705
close #706