### PR TITLE
feat(notifications): add community mention notification parser and toast UI

### DIFF
--- a/apps/api/src/modules/notifications/services/mention-parser.service.ts
+++ b/apps/api/src/modules/notifications/services/mention-parser.service.ts
@@ -1,0 +1,41 @@
+import {
+  mentionNotificationPayloadSchema,
+  type CommentAuthorInfo,
+  type MentionTag,
+  type MentionNotificationPayload,
+} from '@qyou/shared';
+
+export class MentionParserService {
+  public parseAndNotify(
+    body: string,
+    author: CommentAuthorInfo,
+    caseId: string,
+    commentId: string
+  ): MentionNotificationPayload | null {
+    const mentionRegex = /@([a-zA-Z0-9_]+)/g;
+    const mentions: MentionTag[] = [];
+    let match;
+
+    while ((match = mentionRegex.exec(body)) !== null) {
+      mentions.push({
+        mentionedUsername: match[1],
+        startIndex: match.index,
+        endIndex: match.index + match[0].length,
+      });
+    }
+
+    if (mentions.length === 0) return null;
+
+    const payload: MentionNotificationPayload = {
+      notificationId: `mn_${Date.now()}`,
+      author,
+      caseId,
+      commentId,
+      snippet: body.substring(0, 100) + (body.length > 100 ? '...' : ''),
+      mentions,
+      notifiedAtIso: new Date().toISOString(),
+    };
+
+    return mentionNotificationPayloadSchema.parse(payload);
+  }
+}

--- a/apps/web/src/components/MentionNotificationToast.tsx
+++ b/apps/web/src/components/MentionNotificationToast.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import type { MentionNotificationPayload } from '@qyou/shared';
+
+interface MentionNotificationToastProps {
+  payload: MentionNotificationPayload;
+  onView?: (caseId: string, commentId: string) => void;
+}
+
+export function MentionNotificationToast({ payload, onView }: MentionNotificationToastProps) {
+  return (
+    <div style={{ padding: '12px 16px', background: '#3b82f6', color: '#ffffff', borderRadius: '8px', boxShadow: '0 4px 6px rgba(59, 130, 246, 0.3)', minWidth: '300px', display: 'flex', flexDirection: 'column', gap: '8px' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+        <span style={{ fontSize: '18px' }}>💬</span>
+        <div style={{ fontWeight: 'bold', fontSize: '14px' }}>
+          {payload.author.username} mentioned you
+        </div>
+      </div>
+      <p style={{ margin: 0, fontSize: '13px', fontStyle: 'italic', opacity: 0.9 }}>
+        "{payload.snippet}"
+      </p>
+      {onView && (
+        <button onClick={() => onView(payload.caseId, payload.commentId)} style={{ alignSelf: 'flex-start', background: '#ffffff', color: '#1e3a8a', border: 'none', borderRadius: '4px', padding: '4px 10px', fontSize: '12px', fontWeight: 'bold', cursor: 'pointer', marginTop: '4px' }}>
+          View Reply
+        </button>
+      )}
+    </div>
+  );
+}

--- a/docs/community-mention-notifications-guide.md
+++ b/docs/community-mention-notifications-guide.md
@@ -1,0 +1,14 @@
+# Community Mention Notifications Guide
+
+This document details the @mention parsing logic, notification event payloads, and toast UI styles for community reply alerts in Sidewalk.
+
+## Architecture
+
+1. **Mention Parser Service**:
+   - `apps/api/src/modules/notifications/services/mention-parser.service.ts`: `MentionParserService` extracting @usernames and building notification events.
+
+2. **Web Mention Toast UI**:
+   - `MentionNotificationToast`: React component rendering styled alert banners for comment mentions.
+
+3. **Validation Schemas & Interfaces**:
+   - `mentionNotificationPayloadSchema` and `MentionNotificationPayload` defined in `@qyou/shared`.

--- a/packages/shared/src/types/community-mentions.types.ts
+++ b/packages/shared/src/types/community-mentions.types.ts
@@ -1,0 +1,21 @@
+export interface CommentAuthorInfo {
+  userId: string;
+  username: string;
+  role: 'citizen' | 'moderator' | 'admin';
+}
+
+export interface MentionTag {
+  mentionedUsername: string;
+  startIndex: number;
+  endIndex: number;
+}
+
+export interface MentionNotificationPayload {
+  notificationId: string;
+  author: CommentAuthorInfo;
+  caseId: string;
+  commentId: string;
+  snippet: string;
+  mentions: MentionTag[];
+  notifiedAtIso: string;
+}

--- a/packages/shared/src/validation/community-mentions.schemas.ts
+++ b/packages/shared/src/validation/community-mentions.schemas.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+export const commentAuthorInfoSchema = z.object({
+  userId: z.string().min(1, 'Author User ID is required.'),
+  username: z.string().min(1),
+  role: z.enum(['citizen', 'moderator', 'admin']),
+});
+
+export const mentionTagSchema = z.object({
+  mentionedUsername: z.string().min(1),
+  startIndex: z.number().int().min(0),
+  endIndex: z.number().int().min(0),
+});
+
+export const mentionNotificationPayloadSchema = z.object({
+  notificationId: z.string().min(1),
+  author: commentAuthorInfoSchema,
+  caseId: z.string().min(1),
+  commentId: z.string().min(1),
+  snippet: z.string().max(250),
+  mentions: z.array(mentionTagSchema),
+  notifiedAtIso: z.string().min(1),
+});
+
+export type MentionNotificationPayloadInput = z.infer<typeof mentionNotificationPayloadSchema>;


### PR DESCRIPTION
Implemented community @mention comment parsing, notification trigger dispatch payloads, and toast UI.

Highlights:
- Created MentionParserService in apps/api/src/modules/notifications extracting mentions and building payloads
- Added MentionNotificationToast React UI component in apps/web/src/components
- Defined mentionNotificationPayloadSchema & commentAuthorInfoSchema in packages/shared
- Documented @mention parsing logic in docs/community-mention-notifications-guide.md

close #727
close #728
close #729
close #730