### PR TITLE
feat(cases): add public activity signals service and ticker UI

### DIFF
--- a/apps/api/src/modules/cases/services/public-activity-signals.service.ts
+++ b/apps/api/src/modules/cases/services/public-activity-signals.service.ts
@@ -1,0 +1,25 @@
+import {
+  signalFeedSummarySchema,
+  type PublicProgressEvent,
+  type SignalFeedSummary,
+} from '@qyou/shared';
+
+export class PublicActivitySignalsService {
+  private readonly events: PublicProgressEvent[] = [];
+
+  public emitSignal(event: PublicProgressEvent): void {
+    this.events.push(event);
+    if (this.events.length > 100) {
+      this.events.shift(); // Keep latest 100
+    }
+  }
+
+  public getRecentSignals(regionId: string): SignalFeedSummary {
+    const summary: SignalFeedSummary = {
+      regionId,
+      recentEvents: this.events.slice(-10).reverse(),
+      lastUpdatedIso: new Date().toISOString(),
+    };
+    return signalFeedSummarySchema.parse(summary);
+  }
+}

--- a/apps/web/src/components/PublicActivitySignalTicker.tsx
+++ b/apps/web/src/components/PublicActivitySignalTicker.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import type { PublicProgressEvent } from '@qyou/shared';
+
+interface PublicActivitySignalTickerProps {
+  events: PublicProgressEvent[];
+}
+
+export function PublicActivitySignalTicker({ events }: PublicActivitySignalTickerProps) {
+  if (!events || events.length === 0) return null;
+
+  return (
+    <div style={{ background: '#f8fafc', borderBottom: '1px solid #e2e8f0', padding: '8px 16px', display: 'flex', overflowX: 'auto', whiteSpace: 'nowrap', gap: '24px', alignItems: 'center' }}>
+      <span style={{ fontWeight: 'bold', fontSize: '12px', color: '#64748b', textTransform: 'uppercase' }}>Live Activity:</span>
+      {events.map((evt) => (
+        <div key={evt.eventId} style={{ display: 'inline-flex', alignItems: 'center', gap: '6px', fontSize: '13px' }}>
+          <span style={{ color: '#0f172a', fontWeight: '500' }}>{evt.caseTitle}</span>
+          <span style={{ color: '#64748b' }}>- {evt.description}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/docs/public-activity-signals-guide.md
+++ b/docs/public-activity-signals-guide.md
@@ -1,0 +1,14 @@
+# Public Activity Signals & Progress Ticker Guide
+
+This document details the public case activity feed schemas, emission services, and live ticker UI patterns in Sidewalk.
+
+## Architecture
+
+1. **Activity Service**:
+   - `apps/api/src/modules/cases/services/public-activity-signals.service.ts`: `PublicActivitySignalsService` handling recent progress event buffers.
+
+2. **Web Ticker UI**:
+   - `PublicActivitySignalTicker`: React UI component for horizontally scrolling live activity updates.
+
+3. **Validation Schemas & Interfaces**:
+   - `publicProgressEventSchema` and `PublicProgressEvent` defined in `@qyou/shared`.

--- a/packages/shared/src/types/public-activity-signals.types.ts
+++ b/packages/shared/src/types/public-activity-signals.types.ts
@@ -1,0 +1,16 @@
+export type ActivitySignalType = 'photo_added' | 'status_updated' | 'comment_posted' | 'city_response';
+
+export interface PublicProgressEvent {
+  eventId: string;
+  caseId: string;
+  caseTitle: string;
+  signalType: ActivitySignalType;
+  description: string;
+  timestampIso: string;
+}
+
+export interface SignalFeedSummary {
+  regionId: string;
+  recentEvents: PublicProgressEvent[];
+  lastUpdatedIso: string;
+}

--- a/packages/shared/src/validation/public-activity-signals.schemas.ts
+++ b/packages/shared/src/validation/public-activity-signals.schemas.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+export const activitySignalTypeSchema = z.enum([
+  'photo_added',
+  'status_updated',
+  'comment_posted',
+  'city_response',
+]);
+
+export const publicProgressEventSchema = z.object({
+  eventId: z.string().min(1, 'Event ID is required.'),
+  caseId: z.string().min(1, 'Case ID is required.'),
+  caseTitle: z.string().min(1),
+  signalType: activitySignalTypeSchema,
+  description: z.string().min(1),
+  timestampIso: z.string().min(1),
+});
+
+export const signalFeedSummarySchema = z.object({
+  regionId: z.string().min(1),
+  recentEvents: z.array(publicProgressEventSchema),
+  lastUpdatedIso: z.string().min(1),
+});
+
+export type PublicProgressEventInput = z.infer<typeof publicProgressEventSchema>;
+export type SignalFeedSummaryInput = z.infer<typeof signalFeedSummarySchema>;


### PR DESCRIPTION
Implemented public case progress activity emission, schemas, and scrolling ticker UI.

Highlights:
- Created PublicActivitySignalsService in apps/api/src/modules/cases exposing recent progress feeds
- Added PublicActivitySignalTicker React UI component in apps/web/src/components
- Defined publicProgressEventSchema & signalFeedSummarySchema in packages/shared
- Documented public signal patterns in docs/public-activity-signals-guide.md

close #685
close #684
close #683
close #682