### PR TITLE
feat(notifications): add scheduled notification digest payloads and banner UI

### DIFF
--- a/apps/api/src/modules/notifications/services/digest-scheduler.service.ts
+++ b/apps/api/src/modules/notifications/services/digest-scheduler.service.ts
@@ -1,0 +1,33 @@
+import {
+  digestPayloadSchema,
+  type DigestScheduleFrequency,
+  type DigestPayload,
+  type NotificationSummaryItem,
+} from '@qyou/shared';
+
+export class DigestSchedulerService {
+  public generateDigest(
+    recipientId: string,
+    frequency: DigestScheduleFrequency,
+    rawNotifications: any[]
+  ): DigestPayload | null {
+    if (frequency === 'none' || rawNotifications.length === 0) return null;
+
+    const items: NotificationSummaryItem[] = rawNotifications.slice(0, 5).map(n => ({
+      id: n.id,
+      title: n.title,
+      snippet: n.body.substring(0, 50),
+      type: n.type,
+    }));
+
+    const payload: DigestPayload = {
+      recipientId,
+      frequency,
+      items,
+      generatedAtIso: new Date().toISOString(),
+      totalUnreadCount: rawNotifications.length,
+    };
+
+    return digestPayloadSchema.parse(payload);
+  }
+}

--- a/apps/web/src/components/NotificationDigestBanner.tsx
+++ b/apps/web/src/components/NotificationDigestBanner.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+interface NotificationDigestBannerProps {
+  onEnableDigest: (frequency: 'daily' | 'weekly') => void;
+  onDismiss: () => void;
+}
+
+export function NotificationDigestBanner({ onEnableDigest, onDismiss }: NotificationDigestBannerProps) {
+  return (
+    <div style={{ background: '#fef3c7', border: '1px solid #f59e0b', borderRadius: '8px', padding: '16px', display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '16px' }}>
+      <div>
+        <h4 style={{ margin: '0 0 4px 0', color: '#92400e', fontSize: '15px' }}>Too many alerts?</h4>
+        <p style={{ margin: 0, color: '#b45309', fontSize: '13px' }}>
+          Switch to a daily or weekly digest to get a summary of civic updates instead of real-time pings.
+        </p>
+      </div>
+      <div style={{ display: 'flex', gap: '8px' }}>
+        <button onClick={() => onEnableDigest('daily')} style={{ background: '#f59e0b', color: '#fff', border: 'none', borderRadius: '4px', padding: '6px 12px', cursor: 'pointer', fontWeight: 'bold' }}>
+          Daily
+        </button>
+        <button onClick={() => onEnableDigest('weekly')} style={{ background: '#d97706', color: '#fff', border: 'none', borderRadius: '4px', padding: '6px 12px', cursor: 'pointer', fontWeight: 'bold' }}>
+          Weekly
+        </button>
+        <button onClick={onDismiss} style={{ background: 'transparent', color: '#92400e', border: 'none', textDecoration: 'underline', cursor: 'pointer', padding: '6px' }}>
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/docs/notification-digest-guide.md
+++ b/docs/notification-digest-guide.md
@@ -1,0 +1,14 @@
+# Scheduled Notification Digests Guide
+
+This document details the scheduled summary aggregation logic for daily or weekly notification roundups in Sidewalk.
+
+## Architecture
+
+1. **Digest Scheduler Service**:
+   - `apps/api/src/modules/notifications/services/digest-scheduler.service.ts`: Groups pending notifications into a single email/push payload based on user cadence.
+
+2. **Web Upsell Banner**:
+   - `NotificationDigestBanner`: React UI component for prompting active users to switch to batched digests.
+
+3. **Validation Schemas & Interfaces**:
+   - `digestPayloadSchema` and `DigestPayload` defined in `@qyou/shared`.

--- a/packages/shared/src/types/notification-digest.types.ts
+++ b/packages/shared/src/types/notification-digest.types.ts
@@ -1,0 +1,16 @@
+export type DigestScheduleFrequency = 'daily' | 'weekly' | 'none';
+
+export interface NotificationSummaryItem {
+  id: string;
+  title: string;
+  snippet: string;
+  type: string;
+}
+
+export interface DigestPayload {
+  recipientId: string;
+  frequency: DigestScheduleFrequency;
+  items: NotificationSummaryItem[];
+  generatedAtIso: string;
+  totalUnreadCount: number;
+}

--- a/packages/shared/src/validation/notification-digest.schemas.ts
+++ b/packages/shared/src/validation/notification-digest.schemas.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+export const digestScheduleFrequencySchema = z.enum(['daily', 'weekly', 'none']);
+
+export const notificationSummaryItemSchema = z.object({
+  id: z.string().min(1),
+  title: z.string().min(1),
+  snippet: z.string().min(1),
+  type: z.string().min(1),
+});
+
+export const digestPayloadSchema = z.object({
+  recipientId: z.string().min(1),
+  frequency: digestScheduleFrequencySchema,
+  items: z.array(notificationSummaryItemSchema),
+  generatedAtIso: z.string().min(1),
+  totalUnreadCount: z.number().int().min(0),
+});
+
+export type DigestPayloadInput = z.infer<typeof digestPayloadSchema>;


### PR DESCRIPTION
Implemented scheduled summary aggregation logic for daily or weekly notification digests.

Highlights:
- Created DigestSchedulerService in apps/api/src/modules/notifications generating batched summaries
- Added NotificationDigestBanner React UI component in apps/web/src/components
- Defined digestPayloadSchema in packages/shared
- Documented scheduled digests in docs/notification-digest-guide.md

close #723
close #724
close #725
close #726