### PR TITLE
feat(notifications): add refined in-app toast and banner UI patterns

### DIFF
--- a/apps/api/src/modules/notifications/services/toast-trigger.service.ts
+++ b/apps/api/src/modules/notifications/services/toast-trigger.service.ts
@@ -1,0 +1,20 @@
+import {
+  toastNotificationSchema,
+  type ToastNotification,
+  type StatusChangeContext,
+} from '@qyou/shared';
+
+export class ToastTriggerService {
+  public triggerStatusChangeToast(context: StatusChangeContext): ToastNotification {
+    const payload: ToastNotification = {
+      toastId: `toast_${Date.now()}`,
+      type: 'success',
+      title: 'Status Updated',
+      message: `Case status changed from ${context.oldStatus} to ${context.newStatus}`,
+      context,
+      durationMs: 4000,
+    };
+
+    return toastNotificationSchema.parse(payload);
+  }
+}

--- a/apps/web/src/components/StatusChangeBanner.tsx
+++ b/apps/web/src/components/StatusChangeBanner.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import type { BannerAlert } from '@qyou/shared';
+
+interface StatusChangeBannerProps {
+  alert: BannerAlert;
+}
+
+export function StatusChangeBanner({ alert }: StatusChangeBannerProps) {
+  const [isVisible, setIsVisible] = useState(true);
+
+  if (!isVisible) return null;
+
+  return (
+    <div style={{ background: '#3b82f6', color: '#fff', padding: '12px 24px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+      <span style={{ fontSize: '14px', fontWeight: '500' }}>{alert.content}</span>
+      <div style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
+        {alert.actionUrl && (
+          <a href={alert.actionUrl} style={{ color: '#fff', textDecoration: 'underline', fontSize: '14px' }}>
+            View Details
+          </a>
+        )}
+        {alert.isDismissible && (
+          <button onClick={() => setIsVisible(false)} style={{ background: 'transparent', border: 'none', color: '#fff', cursor: 'pointer', fontSize: '16px', fontWeight: 'bold' }}>
+            ×
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/docs/toast-banner-patterns-guide.md
+++ b/docs/toast-banner-patterns-guide.md
@@ -1,0 +1,14 @@
+# Toast and Banner Patterns Guide
+
+This document details the refined in-app toast and banner UI patterns for real-time status change alerts in Sidewalk.
+
+## Architecture
+
+1. **Toast Trigger Service**:
+   - `apps/api/src/modules/notifications/services/toast-trigger.service.ts`: Dispatches status change payloads formatted for client-side consumption.
+
+2. **Web Banner Component**:
+   - `StatusChangeBanner`: React component displaying persistent or dismissible global banners.
+
+3. **Validation Schemas & Interfaces**:
+   - `toastNotificationSchema` and `ToastNotification` defined in `@qyou/shared`.

--- a/packages/shared/src/types/toast-patterns.types.ts
+++ b/packages/shared/src/types/toast-patterns.types.ts
@@ -1,0 +1,22 @@
+export interface StatusChangeContext {
+  caseId: string;
+  oldStatus: string;
+  newStatus: string;
+  updatedBy: string;
+}
+
+export interface ToastNotification {
+  toastId: string;
+  type: 'info' | 'success' | 'warning' | 'error';
+  title: string;
+  message: string;
+  context?: StatusChangeContext;
+  durationMs: number;
+}
+
+export interface BannerAlert {
+  bannerId: string;
+  isDismissible: boolean;
+  content: string;
+  actionUrl?: string;
+}

--- a/packages/shared/src/validation/toast-patterns.schemas.ts
+++ b/packages/shared/src/validation/toast-patterns.schemas.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+export const statusChangeContextSchema = z.object({
+  caseId: z.string().min(1),
+  oldStatus: z.string().min(1),
+  newStatus: z.string().min(1),
+  updatedBy: z.string().min(1),
+});
+
+export const toastNotificationSchema = z.object({
+  toastId: z.string().min(1),
+  type: z.enum(['info', 'success', 'warning', 'error']),
+  title: z.string().min(1),
+  message: z.string().min(1),
+  context: statusChangeContextSchema.optional(),
+  durationMs: z.number().int().min(1000).default(5000),
+});
+
+export const bannerAlertSchema = z.object({
+  bannerId: z.string().min(1),
+  isDismissible: z.boolean().default(true),
+  content: z.string().min(1),
+  actionUrl: z.string().url().optional(),
+});
+
+export type ToastNotificationInput = z.infer<typeof toastNotificationSchema>;
+export type BannerAlertInput = z.infer<typeof bannerAlertSchema>;


### PR DESCRIPTION
Implemented refined toast payloads and dismissible global banners for real-time status change alerts.

Highlights:
- Created ToastTriggerService in apps/api/src/modules/notifications dispatching formatted payloads
- Added StatusChangeBanner React UI component in apps/web/src/components
- Defined toastNotificationSchema & bannerAlertSchema in packages/shared
- Documented toast/banner patterns in docs/toast-banner-patterns-guide.md

close #738
close #737
close #736
close #735