### PR TITLE
feat(cases): refine public activity signals feed and ticker UI

### DIFF
--- a/apps/api/src/modules/cases/services/refined-activity-signals.service.ts
+++ b/apps/api/src/modules/cases/services/refined-activity-signals.service.ts
@@ -1,0 +1,26 @@
+import {
+  refinedProgressEventSchema,
+  activityFeedStateSchema,
+  type RefinedProgressEvent,
+  type ActivityFeedState,
+} from '@qyou/shared';
+
+export class RefinedActivitySignalsService {
+  private readonly events: RefinedProgressEvent[] = [];
+
+  public emitSignal(event: RefinedProgressEvent): void {
+    this.events.unshift(event);
+    if (this.events.length > 50) {
+      this.events.pop(); // keep top 50
+    }
+  }
+
+  public getFeedState(): ActivityFeedState {
+    const state: ActivityFeedState = {
+      events: this.events,
+      lastPolledIso: new Date().toISOString(),
+      isLive: true,
+    };
+    return activityFeedStateSchema.parse(state);
+  }
+}

--- a/apps/web/src/components/RefinedActivitySignalTicker.tsx
+++ b/apps/web/src/components/RefinedActivitySignalTicker.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import type { ActivityFeedState } from '@qyou/shared';
+
+interface RefinedActivitySignalTickerProps {
+  state: ActivityFeedState;
+}
+
+export function RefinedActivitySignalTicker({ state }: RefinedActivitySignalTickerProps) {
+  if (!state.events || state.events.length === 0) return null;
+
+  return (
+    <div style={{ background: '#0f172a', padding: '10px 20px', display: 'flex', overflowX: 'hidden', whiteSpace: 'nowrap', alignItems: 'center' }}>
+      <div style={{ marginRight: '16px', fontWeight: 'bold', fontSize: '13px', color: '#38bdf8', textTransform: 'uppercase', display: 'flex', alignItems: 'center', gap: '6px' }}>
+        {state.isLive && <span style={{ width: '8px', height: '8px', borderRadius: '50%', background: '#ef4444', animation: 'pulse 1.5s infinite' }} />}
+        Live
+      </div>
+      <div style={{ display: 'flex', gap: '32px', animation: 'marquee 30s linear infinite' }}>
+        {state.events.map((evt) => (
+          <div key={evt.id} style={{ display: 'inline-flex', alignItems: 'center', gap: '8px', fontSize: '14px' }}>
+            <span style={{ color: evt.theme === 'highlight' ? '#fcd34d' : evt.theme === 'urgent' ? '#f87171' : '#f8fafc', fontWeight: '600' }}>
+              {evt.title}
+            </span>
+            <span style={{ color: '#94a3b8' }}>- {evt.summary}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/docs/refined-activity-signals-guide.md
+++ b/docs/refined-activity-signals-guide.md
@@ -1,0 +1,14 @@
+# Refined Public Activity Signals Guide
+
+This document details the improved public activity feed service and the visually refined live scrolling ticker in Sidewalk.
+
+## Architecture
+
+1. **Activity Service**:
+   - `apps/api/src/modules/cases/services/refined-activity-signals.service.ts`: Handles aggregating the latest 50 live events for broad consumption.
+
+2. **Web Refined Ticker UI**:
+   - `RefinedActivitySignalTicker`: React UI component for horizontally scrolling live activity updates with a pulse indicator and semantic themes.
+
+3. **Validation Schemas & Interfaces**:
+   - `refinedProgressEventSchema` and `RefinedProgressEvent` defined in `@qyou/shared`.

--- a/packages/shared/src/types/refined-activity-signals.types.ts
+++ b/packages/shared/src/types/refined-activity-signals.types.ts
@@ -1,0 +1,16 @@
+export type SignalTheme = 'default' | 'highlight' | 'urgent';
+
+export interface RefinedProgressEvent {
+  id: string;
+  topicId: string;
+  title: string;
+  summary: string;
+  theme: SignalTheme;
+  publishedAtIso: string;
+}
+
+export interface ActivityFeedState {
+  events: RefinedProgressEvent[];
+  lastPolledIso: string;
+  isLive: boolean;
+}

--- a/packages/shared/src/validation/refined-activity-signals.schemas.ts
+++ b/packages/shared/src/validation/refined-activity-signals.schemas.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+export const signalThemeSchema = z.enum(['default', 'highlight', 'urgent']);
+
+export const refinedProgressEventSchema = z.object({
+  id: z.string().min(1),
+  topicId: z.string().min(1),
+  title: z.string().min(1),
+  summary: z.string().min(1),
+  theme: signalThemeSchema.default('default'),
+  publishedAtIso: z.string().min(1),
+});
+
+export const activityFeedStateSchema = z.object({
+  events: z.array(refinedProgressEventSchema),
+  lastPolledIso: z.string().min(1),
+  isLive: z.boolean().default(true),
+});
+
+export type RefinedProgressEventInput = z.infer<typeof refinedProgressEventSchema>;
+export type ActivityFeedStateInput = z.infer<typeof activityFeedStateSchema>;


### PR DESCRIPTION
Implemented refined public case progress activity emission, schemas, and styled scrolling ticker UI.

Highlights:
- Created RefinedActivitySignalsService in apps/api/src/modules/cases aggregating live events
- Added RefinedActivitySignalTicker React UI component in apps/web/src/components
- Defined refinedProgressEventSchema in packages/shared
- Documented refined signal patterns in docs/refined-activity-signals-guide.md

close #734
close #733
close #732
close #731