### PR TITLE
feat(notifications): add alert preview copy generation and explainer UI

### DIFF
--- a/apps/api/src/modules/notifications/services/alert-preview.service.ts
+++ b/apps/api/src/modules/notifications/services/alert-preview.service.ts
@@ -1,0 +1,44 @@
+import {
+  alertPreviewPayloadSchema,
+  type ExplanationContext,
+  type AlertPreviewPayload,
+} from '@qyou/shared';
+
+export class AlertPreviewService {
+  public generatePreview(
+    notificationId: string,
+    headline: string,
+    previewBody: string,
+    context: ExplanationContext
+  ): AlertPreviewPayload {
+    let explanationCopy = '';
+
+    switch (context.reasonCode) {
+      case 'followed_case':
+        explanationCopy = `You're receiving this because you followed the case "${context.caseTitle}".`;
+        break;
+      case 'subscribed_topic':
+        explanationCopy = `You're receiving this because you subscribed to the topic "${context.topicName}".`;
+        break;
+      case 'nearby_alert':
+        explanationCopy = `This alert is happening ${context.distanceMiles} miles from your registered neighborhood.`;
+        break;
+      case 'mentioned':
+        explanationCopy = 'You were mentioned in a comment.';
+        break;
+      case 'staff_assignment':
+        explanationCopy = 'This case was assigned to you by a dispatcher.';
+        break;
+    }
+
+    const payload: AlertPreviewPayload = {
+      notificationId,
+      headline,
+      previewBody,
+      explanationCopy,
+      context,
+    };
+
+    return alertPreviewPayloadSchema.parse(payload);
+  }
+}

--- a/apps/web/src/components/AlertPreviewExplainer.tsx
+++ b/apps/web/src/components/AlertPreviewExplainer.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import type { AlertPreviewPayload } from '@qyou/shared';
+
+interface AlertPreviewExplainerProps {
+  payload: AlertPreviewPayload;
+}
+
+export function AlertPreviewExplainer({ payload }: AlertPreviewExplainerProps) {
+  return (
+    <div style={{ padding: '16px', background: '#f8fafc', borderRadius: '8px', border: '1px solid #e2e8f0' }}>
+      <h4 style={{ margin: '0 0 8px 0', color: '#0f172a', fontSize: '16px' }}>{payload.headline}</h4>
+      <p style={{ margin: '0 0 12px 0', color: '#334155', fontSize: '14px', lineHeight: '1.5' }}>
+        {payload.previewBody}
+      </p>
+      <div style={{ borderTop: '1px dashed #cbd5e1', paddingTop: '12px' }}>
+        <p style={{ margin: 0, color: '#64748b', fontSize: '12px', fontStyle: 'italic' }}>
+          ℹ️ {payload.explanationCopy}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/docs/alert-preview-guide.md
+++ b/docs/alert-preview-guide.md
@@ -1,0 +1,14 @@
+# Alert Preview & Explanation Guide
+
+This document explains the logic used to generate human-readable contextual copy explaining why a specific notification was routed to a user in Sidewalk.
+
+## Architecture
+
+1. **Alert Preview Service**:
+   - `apps/api/src/modules/notifications/services/alert-preview.service.ts`: Translates system trigger reason codes into clear explanation strings.
+
+2. **Web Explainer Component**:
+   - `AlertPreviewExplainer`: React component rendering the notification body with an attached explanation footer.
+
+3. **Validation Schemas & Interfaces**:
+   - `alertPreviewPayloadSchema` and `AlertPreviewPayload` defined in `@qyou/shared`.

--- a/packages/shared/src/types/alert-preview.types.ts
+++ b/packages/shared/src/types/alert-preview.types.ts
@@ -1,0 +1,16 @@
+export type TriggerReasonCode = 'subscribed_topic' | 'followed_case' | 'mentioned' | 'nearby_alert' | 'staff_assignment';
+
+export interface ExplanationContext {
+  reasonCode: TriggerReasonCode;
+  topicName?: string;
+  caseTitle?: string;
+  distanceMiles?: number;
+}
+
+export interface AlertPreviewPayload {
+  notificationId: string;
+  headline: string;
+  previewBody: string;
+  explanationCopy: string;
+  context: ExplanationContext;
+}

--- a/packages/shared/src/validation/alert-preview.schemas.ts
+++ b/packages/shared/src/validation/alert-preview.schemas.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+export const triggerReasonCodeSchema = z.enum([
+  'subscribed_topic',
+  'followed_case',
+  'mentioned',
+  'nearby_alert',
+  'staff_assignment',
+]);
+
+export const explanationContextSchema = z.object({
+  reasonCode: triggerReasonCodeSchema,
+  topicName: z.string().optional(),
+  caseTitle: z.string().optional(),
+  distanceMiles: z.number().optional(),
+});
+
+export const alertPreviewPayloadSchema = z.object({
+  notificationId: z.string().min(1),
+  headline: z.string().min(1),
+  previewBody: z.string().min(1),
+  explanationCopy: z.string().min(1),
+  context: explanationContextSchema,
+});
+
+export type AlertPreviewPayloadInput = z.infer<typeof alertPreviewPayloadSchema>;


### PR DESCRIPTION
Implemented context-aware human-readable explanation copy to explain why alerts are triggered.

Highlights:
- Created AlertPreviewService in apps/api/src/modules/notifications generating explanation strings
- Added AlertPreviewExplainer React UI component in apps/web/src/components
- Defined alertPreviewPayloadSchema in packages/shared
- Documented preview structures in docs/alert-preview-guide.md

close #722
close #721
close #720
close #719