### PR TITLE
feat(notifications): implement email summary templates for daily and weekly digests

### DIFF
--- a/apps/api/src/modules/notifications/services/email-summary.service.ts
+++ b/apps/api/src/modules/notifications/services/email-summary.service.ts
@@ -1,0 +1,37 @@
+import {
+  emailDigestTemplateSchema,
+  type EmailDigestTemplate,
+  type DigestRecipient,
+  type DigestItem,
+} from '@qyou/shared';
+
+export class EmailSummaryService {
+  public generateDigest(
+    recipient: DigestRecipient,
+    frequency: 'daily' | 'weekly',
+    items: DigestItem[]
+  ): EmailDigestTemplate {
+    const payload: EmailDigestTemplate = {
+      templateId: `digest_${frequency}_${Date.now()}`,
+      frequency,
+      recipient,
+      items,
+      generatedAtIso: new Date().toISOString(),
+    };
+
+    return emailDigestTemplateSchema.parse(payload);
+  }
+
+  public renderHtml(template: EmailDigestTemplate): string {
+    const listHtml = template.items
+      .map((item) => `<li><strong>${item.title}</strong>: ${item.description}</li>`)
+      .join('');
+    
+    return `
+      <div>
+        <h1>Your ${template.frequency} Civic Update, ${template.recipient.name}</h1>
+        <ul>${listHtml}</ul>
+      </div>
+    `;
+  }
+}

--- a/apps/web/src/components/EmailDigestPreview.tsx
+++ b/apps/web/src/components/EmailDigestPreview.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import type { EmailDigestTemplate } from '@qyou/shared';
+
+interface EmailDigestPreviewProps {
+  template: EmailDigestTemplate;
+}
+
+export function EmailDigestPreview({ template }: EmailDigestPreviewProps) {
+  return (
+    <div style={{ padding: '24px', background: '#f8fafc', border: '1px solid #e2e8f0', borderRadius: '12px', maxWidth: '600px', margin: '0 auto', fontFamily: 'sans-serif' }}>
+      <h2 style={{ color: '#0f172a', margin: '0 0 16px 0', fontSize: '20px', borderBottom: '2px solid #cbd5e1', paddingBottom: '8px' }}>
+        Your {template.frequency} Civic Update, {template.recipient.name}
+      </h2>
+      <ul style={{ listStyleType: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '16px' }}>
+        {template.items.map((item) => (
+          <li key={item.id} style={{ background: '#ffffff', padding: '16px', borderRadius: '8px', borderLeft: '4px solid #3b82f6' }}>
+            <div style={{ fontSize: '12px', color: '#64748b', textTransform: 'uppercase', marginBottom: '4px', fontWeight: 'bold' }}>
+              {item.category}
+            </div>
+            <div style={{ fontSize: '16px', fontWeight: 'bold', color: '#1e293b', marginBottom: '8px' }}>
+              {item.title}
+            </div>
+            <div style={{ fontSize: '14px', color: '#334155', lineHeight: '1.5' }}>
+              {item.description}
+            </div>
+          </li>
+        ))}
+      </ul>
+      <div style={{ marginTop: '24px', paddingTop: '16px', borderTop: '1px solid #e2e8f0', fontSize: '12px', color: '#94a3b8', textAlign: 'center' }}>
+        Sent to {template.recipient.email} • Generated at {new Date(template.generatedAtIso).toLocaleString()}
+      </div>
+    </div>
+  );
+}

--- a/docs/email-summary-templates-guide.md
+++ b/docs/email-summary-templates-guide.md
@@ -1,0 +1,14 @@
+# Email Summary Templates Guide
+
+This document details the template generation for daily and weekly scheduled update digests in Sidewalk.
+
+## Architecture
+
+1. **Email Summary Service**:
+   - `apps/api/src/modules/notifications/services/email-summary.service.ts`: Populates HTML payload structures based on scheduled intervals.
+
+2. **Web Preview UI**:
+   - `EmailDigestPreview`: React component used in the admin panel to preview how generated email templates look.
+
+3. **Validation Schemas & Interfaces**:
+   - `emailDigestTemplateSchema` and `EmailDigestTemplate` defined in `@qyou/shared`.

--- a/packages/shared/src/types/email-summary.types.ts
+++ b/packages/shared/src/types/email-summary.types.ts
@@ -1,0 +1,20 @@
+export interface DigestRecipient {
+  userId: string;
+  email: string;
+  name: string;
+}
+
+export interface DigestItem {
+  id: string;
+  category: string;
+  title: string;
+  description: string;
+}
+
+export interface EmailDigestTemplate {
+  templateId: string;
+  frequency: 'daily' | 'weekly';
+  recipient: DigestRecipient;
+  items: DigestItem[];
+  generatedAtIso: string;
+}

--- a/packages/shared/src/validation/email-summary.schemas.ts
+++ b/packages/shared/src/validation/email-summary.schemas.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+export const digestRecipientSchema = z.object({
+  userId: z.string().min(1),
+  email: z.string().email(),
+  name: z.string().min(1),
+});
+
+export const digestItemSchema = z.object({
+  id: z.string().min(1),
+  category: z.string().min(1),
+  title: z.string().min(1),
+  description: z.string().min(1),
+});
+
+export const emailDigestTemplateSchema = z.object({
+  templateId: z.string().min(1),
+  frequency: z.enum(['daily', 'weekly']),
+  recipient: digestRecipientSchema,
+  items: z.array(digestItemSchema),
+  generatedAtIso: z.string().min(1),
+});
+
+export type EmailDigestTemplateInput = z.infer<typeof emailDigestTemplateSchema>;


### PR DESCRIPTION
Implemented HTML template rendering logic and preview UI for scheduled email roundups.

Highlights:
- Created EmailSummaryService in apps/api/src/modules/notifications for rendering HTML digests
- Added EmailDigestPreview React UI component in apps/web/src/components
- Defined emailDigestTemplateSchema in packages/shared
- Documented email templates in docs/email-summary-templates-guide.md

close #714
close #713
close #712
close #711