### PR TITLE
feat(#665): case follow rules tied to report ownership and participation

### DIFF
--- a/apps/api/src/modules/reports/report-assignment.service.ts
+++ b/apps/api/src/modules/reports/report-assignment.service.ts
@@ -3,6 +3,7 @@ import {
   ReportAssignmentModel,
   type AssignmentStatus,
 } from './report-assignment.model.js';
+import { autoFollow } from './report-follow.service.js';
 
 export async function createAssignment(params: {
   reportId: Types.ObjectId;
@@ -16,11 +17,20 @@ export async function createAssignment(params: {
     { status: 'REASSIGNED', releasedAt: new Date() },
   );
 
-  return ReportAssignmentModel.create({
+  const assignment = await ReportAssignmentModel.create({
     ...params,
     status: 'ACTIVE' as AssignmentStatus,
     assignedAt: new Date(),
   });
+
+  // Auto-follow: assignee follows the report
+  await autoFollow({
+    reportId: params.reportId,
+    userId: params.assigneeId,
+    reason: 'ASSIGNEE',
+  });
+
+  return assignment;
 }
 
 export async function getActiveAssignment(reportId: Types.ObjectId) {

--- a/apps/api/src/modules/reports/report-follow.model.ts
+++ b/apps/api/src/modules/reports/report-follow.model.ts
@@ -1,0 +1,57 @@
+import { Schema, model, type HydratedDocument, type Types } from 'mongoose';
+
+const FOLLOW_REASONS = [
+  'OWNER',
+  'COMMENTER',
+  'ASSIGNEE',
+  'STATUS_ACTOR',
+  'MANUAL',
+] as const;
+
+export type FollowReason = (typeof FOLLOW_REASONS)[number];
+
+export interface ReportFollow {
+  reportId: Types.ObjectId;
+  userId: Types.ObjectId;
+  reason: FollowReason;
+  active: boolean;
+  createdAt: Date;
+}
+
+const reportFollowSchema = new Schema<ReportFollow>(
+  {
+    reportId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Report',
+      required: true,
+      index: true,
+    },
+    userId: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true,
+    },
+    reason: {
+      type: String,
+      enum: FOLLOW_REASONS,
+      required: true,
+    },
+    active: {
+      type: Boolean,
+      default: true,
+      index: true,
+    },
+  },
+  { timestamps: true },
+);
+
+reportFollowSchema.index({ reportId: 1, userId: 1 }, { unique: true });
+reportFollowSchema.index({ userId: 1, active: 1 });
+
+export type ReportFollowDocument = HydratedDocument<ReportFollow>;
+
+export const ReportFollowModel = model<ReportFollow>(
+  'ReportFollow',
+  reportFollowSchema,
+);

--- a/apps/api/src/modules/reports/report-follow.routes.ts
+++ b/apps/api/src/modules/reports/report-follow.routes.ts
@@ -1,0 +1,200 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import { Types } from 'mongoose';
+import { AppError } from '../../core/errors/app-error';
+import { authenticateToken, requireRole } from '../auth/auth.middleware';
+import { validateRequest } from '../../core/validation/validate-request';
+import {
+  followReportParamsSchema,
+  unfollowReportParamsSchema,
+  listFollowersParamsSchema,
+  followedReportsQuerySchema,
+} from './report-follow.schemas';
+import {
+  followReport,
+  unfollowReport,
+  isFollowing,
+  getFollowers,
+  getFollowerCount,
+  getFollowedReports,
+} from './report-follow.service';
+import { ReportModel } from './report.model';
+
+const router: Router = Router();
+
+router.post(
+  '/:reportId/follow',
+  authenticateToken,
+  requireRole(['CITIZEN', 'AGENCY_ADMIN']),
+  validateRequest({ params: followReportParamsSchema }),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { reportId } = req.params;
+      const userId = req.user?.id;
+
+      if (!userId) {
+        throw new AppError('Unauthorized', 401, 'UNAUTHORIZED');
+      }
+
+      const report = await ReportModel.findById(reportId).lean();
+      if (!report) {
+        throw new AppError('Report not found', 404, 'REPORT_NOT_FOUND');
+      }
+
+      await followReport({
+        reportId: new Types.ObjectId(reportId),
+        userId: new Types.ObjectId(userId),
+        reason: 'MANUAL',
+      });
+
+      return res.status(200).json({ message: 'Now following report' });
+    } catch (error) {
+      return next(error);
+    }
+  },
+);
+
+router.delete(
+  '/:reportId/follow',
+  authenticateToken,
+  requireRole(['CITIZEN', 'AGENCY_ADMIN']),
+  validateRequest({ params: unfollowReportParamsSchema }),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { reportId } = req.params;
+      const userId = req.user?.id;
+
+      if (!userId) {
+        throw new AppError('Unauthorized', 401, 'UNAUTHORIZED');
+      }
+
+      await unfollowReport(
+        new Types.ObjectId(reportId),
+        new Types.ObjectId(userId),
+      );
+
+      return res.status(200).json({ message: 'Unfollowed report' });
+    } catch (error) {
+      return next(error);
+    }
+  },
+);
+
+router.get(
+  '/:reportId/followers',
+  authenticateToken,
+  requireRole(['CITIZEN', 'AGENCY_ADMIN']),
+  validateRequest({ params: listFollowersParamsSchema }),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { reportId } = req.params;
+
+      const report = await ReportModel.findById(reportId).lean();
+      if (!report) {
+        throw new AppError('Report not found', 404, 'REPORT_NOT_FOUND');
+      }
+
+      const [followers, count] = await Promise.all([
+        getFollowers(new Types.ObjectId(reportId)),
+        getFollowerCount(new Types.ObjectId(reportId)),
+      ]);
+
+      return res.status(200).json({
+        data: followers.map((f) => ({
+          userId: String(f.userId),
+          reason: f.reason,
+          followedAt: f.createdAt,
+        })),
+        count,
+      });
+    } catch (error) {
+      return next(error);
+    }
+  },
+);
+
+router.get(
+  '/:reportId/follow-status',
+  authenticateToken,
+  requireRole(['CITIZEN', 'AGENCY_ADMIN']),
+  validateRequest({ params: listFollowersParamsSchema }),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { reportId } = req.params;
+      const userId = req.user?.id;
+
+      if (!userId) {
+        throw new AppError('Unauthorized', 401, 'UNAUTHORIZED');
+      }
+
+      const following = await isFollowing(
+        new Types.ObjectId(reportId),
+        new Types.ObjectId(userId),
+      );
+
+      return res.status(200).json({ following });
+    } catch (error) {
+      return next(error);
+    }
+  },
+);
+
+router.get(
+  '/followed',
+  authenticateToken,
+  requireRole(['CITIZEN', 'AGENCY_ADMIN']),
+  validateRequest({ query: followedReportsQuerySchema }),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) {
+        throw new AppError('Unauthorized', 401, 'UNAUTHORIZED');
+      }
+
+      const { page, pageSize } = req.query as unknown as {
+        page: number;
+        pageSize: number;
+      };
+
+      const followed = await getFollowedReports(new Types.ObjectId(userId));
+
+      const reportIds = followed.map((f) => f.reportId);
+      const reports = await ReportModel.find({ _id: { $in: reportIds } })
+        .sort({ createdAt: -1 })
+        .skip((page - 1) * pageSize)
+        .limit(pageSize)
+        .lean();
+
+      return res.status(200).json({
+        data: reports.map((report) => {
+          const withTimestamps = report as typeof report & {
+            createdAt?: Date;
+            updatedAt?: Date;
+          };
+          const follow = followed.find(
+            (f) => String(f.reportId) === String(report._id),
+          );
+
+          return {
+            id: String(report._id),
+            title: report.title,
+            category: report.category,
+            status: report.status,
+            followReason: follow?.reason ?? null,
+            followedAt: follow?.createdAt ?? null,
+            createdAt: withTimestamps.createdAt?.toISOString() ?? null,
+          };
+        }),
+        pagination: {
+          page,
+          pageSize,
+          total: reportIds.length,
+          totalPages: Math.ceil(reportIds.length / pageSize),
+        },
+      });
+    } catch (error) {
+      return next(error);
+    }
+  },
+);
+
+export default router;

--- a/apps/api/src/modules/reports/report-follow.schemas.ts
+++ b/apps/api/src/modules/reports/report-follow.schemas.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+export const followReportParamsSchema = z.object({
+  reportId: z
+    .string()
+    .trim()
+    .regex(/^[a-fA-F0-9]{24}$/, 'reportId must be a valid ObjectId'),
+});
+
+export const unfollowReportParamsSchema = z.object({
+  reportId: z
+    .string()
+    .trim()
+    .regex(/^[a-fA-F0-9]{24}$/, 'reportId must be a valid ObjectId'),
+});
+
+export const listFollowersParamsSchema = z.object({
+  reportId: z
+    .string()
+    .trim()
+    .regex(/^[a-fA-F0-9]{24}$/, 'reportId must be a valid ObjectId'),
+});
+
+export const followedReportsQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+export type FollowReportParamsDTO = z.infer<typeof followReportParamsSchema>;
+export type UnfollowReportParamsDTO = z.infer<typeof unfollowReportParamsSchema>;
+export type ListFollowersParamsDTO = z.infer<typeof listFollowersParamsSchema>;
+export type FollowedReportsQueryDTO = z.infer<typeof followedReportsQuerySchema>;

--- a/apps/api/src/modules/reports/report-follow.service.ts
+++ b/apps/api/src/modules/reports/report-follow.service.ts
@@ -1,0 +1,74 @@
+import { Types } from 'mongoose';
+import {
+  ReportFollowModel,
+  type FollowReason,
+} from './report-follow.model.js';
+
+export async function followReport(params: {
+  reportId: Types.ObjectId;
+  userId: Types.ObjectId;
+  reason: FollowReason;
+}) {
+  return ReportFollowModel.findOneAndUpdate(
+    { reportId: params.reportId, userId: params.userId },
+    { $set: { active: true, reason: params.reason } },
+    { upsert: true, new: true, setDefaultsOnInsert: true },
+  );
+}
+
+export async function unfollowReport(
+  reportId: Types.ObjectId,
+  userId: Types.ObjectId,
+) {
+  return ReportFollowModel.findOneAndUpdate(
+    { reportId, userId },
+    { $set: { active: false } },
+    { new: true },
+  );
+}
+
+export async function isFollowing(
+  reportId: Types.ObjectId,
+  userId: Types.ObjectId,
+): Promise<boolean> {
+  const follow = await ReportFollowModel.findOne({
+    reportId,
+    userId,
+    active: true,
+  }).lean();
+  return follow !== null;
+}
+
+export async function getFollowers(reportId: Types.ObjectId) {
+  return ReportFollowModel.find({ reportId, active: true })
+    .sort({ createdAt: 1 })
+    .lean();
+}
+
+export async function getFollowerCount(reportId: Types.ObjectId): Promise<number> {
+  return ReportFollowModel.countDocuments({ reportId, active: true });
+}
+
+export async function getFollowedReports(userId: Types.ObjectId) {
+  return ReportFollowModel.find({ userId, active: true })
+    .sort({ createdAt: -1 })
+    .lean();
+}
+
+/**
+ * Auto-follow rules:
+ * - Creator follows on report creation (OWNER)
+ * - Commenter follows when commenting (COMMENTER)
+ * - Admin follows when changing status (STATUS_ACTOR)
+ * - Assignee follows when assigned (ASSIGNEE)
+ *
+ * All auto-follows are idempotent — re-following an already-followed report
+ * updates the reason but keeps the follow active.
+ */
+export async function autoFollow(params: {
+  reportId: Types.ObjectId;
+  userId: Types.ObjectId;
+  reason: FollowReason;
+}) {
+  return followReport(params);
+}

--- a/apps/api/src/modules/reports/reports.controller.ts
+++ b/apps/api/src/modules/reports/reports.controller.ts
@@ -12,6 +12,7 @@ import { ReportModel } from './report.model';
 import { enqueueStellarAnchor } from './reports.anchor.queue';
 import { buildDeterministicSnapshot, hashSnapshot } from './reports.snapshot';
 import { StatusUpdateModel } from './status-update.model';
+import { autoFollow } from './report-follow.service';
 import {
   CreateReportDTO,
   ListReportsQueryDTO,
@@ -140,6 +141,14 @@ export const createReport = async (
       dataHash: contentHash,
     });
 
+    if (reporterId) {
+      await autoFollow({
+        reportId: report._id,
+        userId: new Types.ObjectId(reporterId),
+        reason: 'OWNER',
+      });
+    }
+
     if (mediaUrls.length > 0) {
       await MediaUploadModel.updateMany(
         { url: { $in: mediaUrls } },
@@ -222,6 +231,14 @@ export const updateReportStatus = async (
 
     report.status = status;
     await report.save();
+
+    if (actorId) {
+      await autoFollow({
+        reportId: report._id,
+        userId: actorId,
+        reason: 'STATUS_ACTOR',
+      });
+    }
 
     return res.status(200).json({
       message: 'Status updated and anchored',
@@ -467,6 +484,14 @@ export const addReportComment = async (
       body,
       visibility: req.user?.role === 'AGENCY_ADMIN' ? visibility : 'PUBLIC',
     });
+
+    if (req.user?.id) {
+      await autoFollow({
+        reportId: report._id,
+        userId: new Types.ObjectId(req.user.id),
+        reason: 'COMMENTER',
+      });
+    }
 
     return res.status(201).json({
       id: String(comment._id),

--- a/apps/api/src/modules/reports/reports.routes.ts
+++ b/apps/api/src/modules/reports/reports.routes.ts
@@ -28,8 +28,80 @@ import {
   verifyReportBodySchema,
   verifyStatusBodySchema,
 } from './reports.schemas';
+import {
+  followReportParamsSchema,
+  unfollowReportParamsSchema,
+  listFollowersParamsSchema,
+  followedReportsQuerySchema,
+} from './report-follow.schemas';
+import {
+  followReport,
+  unfollowReport,
+  isFollowing,
+  getFollowers,
+  getFollowerCount,
+  getFollowedReports,
+} from './report-follow.service';
+import { ReportModel } from './report.model';
+import { Types } from 'mongoose';
+import { AppError } from '../../core/errors/app-error';
 
 const router: Router = Router();
+
+router.get(
+  '/followed',
+  authenticateToken,
+  requireRole(['CITIZEN', 'AGENCY_ADMIN']),
+  validateRequest({ query: followedReportsQuerySchema }),
+  async (req, res, next) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) throw new AppError('Unauthorized', 401, 'UNAUTHORIZED');
+
+      const { page, pageSize } = req.query as unknown as {
+        page: number;
+        pageSize: number;
+      };
+
+      const followed = await getFollowedReports(new Types.ObjectId(userId));
+      const reportIds = followed.map((f) => f.reportId);
+      const reports = await ReportModel.find({ _id: { $in: reportIds } })
+        .sort({ createdAt: -1 })
+        .skip((page - 1) * pageSize)
+        .limit(pageSize)
+        .lean();
+
+      return res.status(200).json({
+        data: reports.map((report) => {
+          const withTimestamps = report as typeof report & {
+            createdAt?: Date;
+            updatedAt?: Date;
+          };
+          const follow = followed.find(
+            (f) => String(f.reportId) === String(report._id),
+          );
+          return {
+            id: String(report._id),
+            title: report.title,
+            category: report.category,
+            status: report.status,
+            followReason: follow?.reason ?? null,
+            followedAt: follow?.createdAt ?? null,
+            createdAt: withTimestamps.createdAt?.toISOString() ?? null,
+          };
+        }),
+        pagination: {
+          page,
+          pageSize,
+          total: reportIds.length,
+          totalPages: Math.ceil(reportIds.length / pageSize),
+        },
+      });
+    } catch (error) {
+      return next(error);
+    }
+  },
+);
 
 router.get(
   '/public',
@@ -82,6 +154,109 @@ router.get(
   requireRole(['CITIZEN', 'AGENCY_ADMIN']),
   validateRequest({ params: reportDetailParamsSchema }),
   getReportDetail,
+);
+
+router.post(
+  '/:reportId/follow',
+  authenticateToken,
+  requireRole(['CITIZEN', 'AGENCY_ADMIN']),
+  validateRequest({ params: followReportParamsSchema }),
+  async (req, res, next) => {
+    try {
+      const { reportId } = req.params;
+      const userId = req.user?.id;
+      if (!userId) throw new AppError('Unauthorized', 401, 'UNAUTHORIZED');
+
+      const report = await ReportModel.findById(reportId).lean();
+      if (!report) throw new AppError('Report not found', 404, 'REPORT_NOT_FOUND');
+
+      await followReport({
+        reportId: new Types.ObjectId(reportId),
+        userId: new Types.ObjectId(userId),
+        reason: 'MANUAL',
+      });
+
+      return res.status(200).json({ message: 'Now following report' });
+    } catch (error) {
+      return next(error);
+    }
+  },
+);
+
+router.delete(
+  '/:reportId/follow',
+  authenticateToken,
+  requireRole(['CITIZEN', 'AGENCY_ADMIN']),
+  validateRequest({ params: unfollowReportParamsSchema }),
+  async (req, res, next) => {
+    try {
+      const { reportId } = req.params;
+      const userId = req.user?.id;
+      if (!userId) throw new AppError('Unauthorized', 401, 'UNAUTHORIZED');
+
+      await unfollowReport(
+        new Types.ObjectId(reportId),
+        new Types.ObjectId(userId),
+      );
+
+      return res.status(200).json({ message: 'Unfollowed report' });
+    } catch (error) {
+      return next(error);
+    }
+  },
+);
+
+router.get(
+  '/:reportId/followers',
+  authenticateToken,
+  requireRole(['CITIZEN', 'AGENCY_ADMIN']),
+  validateRequest({ params: listFollowersParamsSchema }),
+  async (req, res, next) => {
+    try {
+      const { reportId } = req.params;
+      const report = await ReportModel.findById(reportId).lean();
+      if (!report) throw new AppError('Report not found', 404, 'REPORT_NOT_FOUND');
+
+      const [followers, count] = await Promise.all([
+        getFollowers(new Types.ObjectId(reportId)),
+        getFollowerCount(new Types.ObjectId(reportId)),
+      ]);
+
+      return res.status(200).json({
+        data: followers.map((f) => ({
+          userId: String(f.userId),
+          reason: f.reason,
+          followedAt: f.createdAt,
+        })),
+        count,
+      });
+    } catch (error) {
+      return next(error);
+    }
+  },
+);
+
+router.get(
+  '/:reportId/follow-status',
+  authenticateToken,
+  requireRole(['CITIZEN', 'AGENCY_ADMIN']),
+  validateRequest({ params: listFollowersParamsSchema }),
+  async (req, res, next) => {
+    try {
+      const { reportId } = req.params;
+      const userId = req.user?.id;
+      if (!userId) throw new AppError('Unauthorized', 401, 'UNAUTHORIZED');
+
+      const following = await isFollowing(
+        new Types.ObjectId(reportId),
+        new Types.ObjectId(userId),
+      );
+
+      return res.status(200).json({ following });
+    } catch (error) {
+      return next(error);
+    }
+  },
 );
 
 router.get(


### PR DESCRIPTION
- ReportFollow model (Mongoose) with OWNER/COMMENTER/ASSIGNEE/STATUS_ACTOR/MANUAL reasons
- Follow service: follow, unfollow, isFollowing, getFollowers, getFollowedReports, autoFollow
- Follow routes: POST/DELETE /:reportId/follow, GET /:reportId/followers, GET /:reportId/follow-status, GET /followed
- Auto-follow hooks in createReport (OWNER), addReportComment (COMMENTER), updateReportStatus (STATUS_ACTOR), createAssignment (ASSIGNEE)
- Zod validation schemas for all follow endpoints

Closes #665